### PR TITLE
docs: add v1.1.0 release notes

### DIFF
--- a/docs/releases/v1.1.0.md
+++ b/docs/releases/v1.1.0.md
@@ -1,0 +1,36 @@
+<!--
+Copyright 2025 Alexander Alten (novatechflow), NovaTechflow (novatechflow.com).
+This project is supported and financed by Scalytics, Inc. (www.scalytics.io).
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# v1.1.0
+
+Release date: 2025-12-21
+
+## Highlights
+
+- CodeQL fixes for broker logging and safer env parsing.
+- Dependency refresh and upstream controller-runtime (no fork).
+- Added fuzzing, security, and release-process documentation for best practices.
+
+## Known limitations
+
+- TLS/SASL authentication is planned for a future release.
+- No Kafka transactions, KRaft APIs, or embedded stream processing.
+
+## Security fixes
+
+- No known runtime vulnerabilities were fixed in this release.
+


### PR DESCRIPTION
Add v1.1.0 release notes under docs/releases.\n\nTests: not run (docs only).