### PR TITLE
docs: align release planning

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -39,7 +39,7 @@ helm upgrade --install kafscale deploy/helm/kafscale \
 
 The chart ships the `KafscaleCluster` and `KafscaleTopic` CRDs so the operator can immediately reconcile resources.  Create a Kubernetes secret that contains your S3 access/secret keys, reference it inside a `KafscaleCluster` resource (see `config/samples/`), and the operator will launch broker pods with the right IAM credentials.
 
-By default, image tags follow the chart `appVersion`. Override `operator.image.tag` and `console.image.tag` to pin a different release (for example, `v0.9.0`).
+By default, image tags follow the chart `appVersion`. Override `operator.image.tag` and `console.image.tag` to pin a different release (for example, `v1.1.0`).
 
 ### Values to pay attention to
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -70,9 +70,11 @@ Kafscale implements a focused subset of the Kafka protocol. Versions below refle
 | Version | Auth Mechanism | Use Case |
 |---------|---------------|----------|
 | v1.0 | None | Internal/dev clusters |
-| v1.1 | SASL/PLAIN | Username/password |
-| v1.1 | SASL/SCRAM-SHA-256/512 | Username/password + challenge-response |
-| v2.0 | SASL/OAUTHBEARER | Enterprise SSO |
+| v1.5 | Auth groundwork | TLS on by default, auth plumbing, and UI/session hardening |
+| v2.0 | SASL/PLAIN | Username/password |
+| v2.0 | SASL/SCRAM-SHA-256/512 | Username/password + challenge-response |
+| v2.0 | ACL authorization | Per-topic/group access control |
 | v2.0 | mTLS | Certificate-based auth |
+| v2.0 | SASL/OAUTHBEARER | Enterprise SSO |
 
 Until auth lands, Kafscale responds to SASL handshake attempts with `UNSUPPORTED_SASL_MECHANISM` (error code 33).

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -28,10 +28,9 @@ Release date: 2025-12-20
 
 ## Known limitations
 
-- TLS/SASL authentication is planned for a future release.
+- TLS/SASL authentication is planned for v1.5+ (see roadmap).
 - No Kafka transactions, KRaft APIs, or embedded stream processing.
 
 ## Security fixes
 
 - No known runtime vulnerabilities were fixed in this release.
-

--- a/docs/releases/v1.1.0.md
+++ b/docs/releases/v1.1.0.md
@@ -27,10 +27,9 @@ Release date: 2025-12-21
 
 ## Known limitations
 
-- TLS/SASL authentication is planned for a future release.
+- TLS/SASL authentication is planned for v1.5+ (see roadmap).
 - No Kafka transactions, KRaft APIs, or embedded stream processing.
 
 ## Security fixes
 
 - No known runtime vulnerabilities were fixed in this release.
-

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -38,6 +38,11 @@ This roadmap tracks completed work and open gaps. It is intentionally high level
 
 ## Open
 
+### Release Planning
+
+- v1.5: authentication groundwork and security hardening
+- v2.0: SASL support and ACL authorization
+
 ### Testing and Hardening
 
 - Performance benchmarks


### PR DESCRIPTION
Align auth roadmap and release examples with v1.5/v2.0 plan.\n\n- Update auth roadmap in docs/protocol.md\n- Update example tag in docs/operations.md\n- Clarify TLS/SASL timing in release notes\n- Add release planning entries in docs/roadmap.md\n\nTests: not run (docs only).