### PR TITLE
Add multi-region support in S3 mit AWS CRR und consumer reads

### DIFF
--- a/api/v1alpha1/kafscalecluster_types.go
+++ b/api/v1alpha1/kafscalecluster_types.go
@@ -43,6 +43,9 @@ type S3Spec struct {
 	Bucket               string `json:"bucket"`
 	Region               string `json:"region"`
 	Endpoint             string `json:"endpoint,omitempty"`
+	ReadBucket           string `json:"readBucket,omitempty"`
+	ReadRegion           string `json:"readRegion,omitempty"`
+	ReadEndpoint         string `json:"readEndpoint,omitempty"`
 	KMSKeyARN            string `json:"kmsKeyArn,omitempty"`
 	CredentialsSecretRef string `json:"credentialsSecretRef"`
 }

--- a/cmd/broker/s3_dual.go
+++ b/cmd/broker/s3_dual.go
@@ -1,0 +1,66 @@
+// Copyright 2025 Alexander Alten (novatechflow), NovaTechflow (novatechflow.com).
+// This project is supported and financed by Scalytics, Inc. (www.scalytics.io).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+
+	"github.com/novatechflow/kafscale/pkg/storage"
+)
+
+type dualS3Client struct {
+	write storage.S3Client
+	read  storage.S3Client
+}
+
+func newDualS3Client(writeClient, readClient storage.S3Client) storage.S3Client {
+	return &dualS3Client{
+		write: writeClient,
+		read:  readClient,
+	}
+}
+
+func (d *dualS3Client) UploadSegment(ctx context.Context, key string, body []byte) error {
+	return d.write.UploadSegment(ctx, key, body)
+}
+
+func (d *dualS3Client) UploadIndex(ctx context.Context, key string, body []byte) error {
+	return d.write.UploadIndex(ctx, key, body)
+}
+
+func (d *dualS3Client) DownloadSegment(ctx context.Context, key string, rng *storage.ByteRange) ([]byte, error) {
+	data, err := d.read.DownloadSegment(ctx, key, rng)
+	if err == nil {
+		return data, nil
+	}
+	return d.write.DownloadSegment(ctx, key, rng)
+}
+
+func (d *dualS3Client) DownloadIndex(ctx context.Context, key string) ([]byte, error) {
+	data, err := d.read.DownloadIndex(ctx, key)
+	if err == nil {
+		return data, nil
+	}
+	return d.write.DownloadIndex(ctx, key)
+}
+
+func (d *dualS3Client) ListSegments(ctx context.Context, prefix string) ([]storage.S3Object, error) {
+	return d.write.ListSegments(ctx, prefix)
+}
+
+func (d *dualS3Client) EnsureBucket(ctx context.Context) error {
+	return d.write.EnsureBucket(ctx)
+}

--- a/deploy/helm/kafscale/crds/kafscaleclusters.yaml
+++ b/deploy/helm/kafscale/crds/kafscaleclusters.yaml
@@ -71,6 +71,12 @@ spec:
                       type: string
                     endpoint:
                       type: string
+                    readBucket:
+                      type: string
+                    readRegion:
+                      type: string
+                    readEndpoint:
+                      type: string
                     kmsKeyArn:
                       type: string
                     credentialsSecretRef:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -55,6 +55,8 @@ Kafscale is a Kafka-compatible, S3-backed message transport system. It keeps bro
          namespace: kafscale
    ```
 
+   Optional for CRR: set `spec.s3.readBucket`, `spec.s3.readRegion`, and `spec.s3.readEndpoint` to point brokers at the replica bucket in their region. Brokers will attempt reads from the replica and fall back to the primary on misses.
+
 4. **Mount credentials into brokers**  
    The operator projects the secret into broker pods and sets env vars (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, etc.). Credential rotation is automatic—update the secret and the operator will restart brokers through the drain RPC.
 
@@ -62,7 +64,7 @@ Kafscale is a Kafka-compatible, S3-backed message transport system. It keeps bro
    The operator validates bucket access (list + put) during reconciliation. Check operator logs if the CRD status reports `S3ValidationFailed`.
 
 6. **Broker overrides (optional)**  
-   Brokers can read overrides from environment variables if you need different values per pod: `KAFSCALE_S3_BUCKET`, `KAFSCALE_S3_REGION`, `KAFSCALE_S3_ENDPOINT`, `KAFSCALE_S3_PATH_STYLE`, `KAFSCALE_S3_KMS_ARN`, `KAFSCALE_CACHE_BYTES`, `KAFSCALE_READAHEAD_SEGMENTS`, `KAFSCALE_SEGMENT_BYTES`, and `KAFSCALE_FLUSH_INTERVAL_MS`.
+   Brokers can read overrides from environment variables if you need different values per pod: `KAFSCALE_S3_BUCKET`, `KAFSCALE_S3_REGION`, `KAFSCALE_S3_ENDPOINT`, `KAFSCALE_S3_READ_BUCKET`, `KAFSCALE_S3_READ_REGION`, `KAFSCALE_S3_READ_ENDPOINT`, `KAFSCALE_S3_PATH_STYLE`, `KAFSCALE_S3_KMS_ARN`, `KAFSCALE_CACHE_BYTES`, `KAFSCALE_READAHEAD_SEGMENTS`, `KAFSCALE_SEGMENT_BYTES`, and `KAFSCALE_FLUSH_INTERVAL_MS`.
 
 ## Metadata Store (etcd)
 

--- a/pkg/operator/cluster_controller.go
+++ b/pkg/operator/cluster_controller.go
@@ -146,6 +146,15 @@ func (r *ClusterReconciler) brokerContainer(cluster *kafscalev1alpha1.KafscaleCl
 		env = append(env, corev1.EnvVar{Name: "KAFSCALE_S3_ENDPOINT", Value: cluster.Spec.S3.Endpoint})
 		env = append(env, corev1.EnvVar{Name: "KAFSCALE_S3_PATH_STYLE", Value: "true"})
 	}
+	if strings.TrimSpace(cluster.Spec.S3.ReadBucket) != "" {
+		env = append(env, corev1.EnvVar{Name: "KAFSCALE_S3_READ_BUCKET", Value: cluster.Spec.S3.ReadBucket})
+	}
+	if strings.TrimSpace(cluster.Spec.S3.ReadRegion) != "" {
+		env = append(env, corev1.EnvVar{Name: "KAFSCALE_S3_READ_REGION", Value: cluster.Spec.S3.ReadRegion})
+	}
+	if strings.TrimSpace(cluster.Spec.S3.ReadEndpoint) != "" {
+		env = append(env, corev1.EnvVar{Name: "KAFSCALE_S3_READ_ENDPOINT", Value: cluster.Spec.S3.ReadEndpoint})
+	}
 	if cluster.Spec.Config.SegmentBytes > 0 {
 		env = append(env, corev1.EnvVar{
 			Name:  "KAFSCALE_SEGMENT_BYTES",


### PR DESCRIPTION
## Summary

- Add multi-region support in S3 mit AWS CRR und consumer reads

## Testing
- [ok] `make test-produce-consume` (broker changes)
- [ok] `make test-consumer-group` (group changes)

## Checklist

- [x] Added/updated unit tests for new logic
- [x] Added/updated e2e coverage for bug fixes
- [x] Added license headers to new files
