### PR TITLE
chore: prep v1.3.0 release

### DIFF
--- a/deploy/helm/kafscale/Chart.yaml
+++ b/deploy/helm/kafscale/Chart.yaml
@@ -19,5 +19,5 @@ description: Helm chart for the Kafscale operator and console
 home: https://github.com/novatechflow/kafscale
 icon: https://raw.githubusercontent.com/novatechflow/kafscale/main/docs/assets/icon.png
 type: application
-version: 0.1.0
-appVersion: "v1.2.0"
+version: 0.2.0
+appVersion: "v1.3.0"

--- a/docs/releases/v1.3.0.md
+++ b/docs/releases/v1.3.0.md
@@ -1,0 +1,35 @@
+<!--
+Copyright 2025 Alexander Alten (novatechflow), NovaTechflow (novatechflow.com).
+This project is supported and financed by Scalytics, Inc. (www.scalytics.io).
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# v1.3.0
+
+Release date: 2025-12-28
+
+## Highlights
+
+- Fixed advertised broker metadata and added external access e2e coverage.
+- Improved Kafka client compatibility (including Java producer) with expanded e2e tests.
+- Streamlined Kafka CLI setup by skipping kind image load.
+
+## Known limitations
+
+- TLS/SASL authentication is planned for v1.5+ (see roadmap).
+- No Kafka transactions, KRaft APIs, or embedded stream processing.
+
+## Security fixes
+
+- No known runtime vulnerabilities were fixed in this release.


### PR DESCRIPTION
## Summary
- add v1.3.0 release notes
- bump Helm chart version/appVersion to v1.3.0

## Testing
- not run (docs-only changes)