### PR TITLE
Log default env usage in prod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ MINIO_ROOT_PASSWORD ?= minioadmin
 MINIO_BUCKET ?= kafscale
 KAFSCALE_KIND_CLUSTER ?= kafscale-demo
 KAFSCALE_DEMO_NAMESPACE ?= kafscale-demo
+KAFSCALE_UI_USERNAME ?= kafscaleadmin
+KAFSCALE_UI_PASSWORD ?= kafscale
 BROKER_PORT ?= 39092
 BROKER_PORTS ?= 39092 39093 39094
 
@@ -292,6 +294,8 @@ demo-platform: docker-build ## Launch a full platform demo on kind (operator HA 
 	  --set operator.image.tag=$$OPERATOR_TAG \
 	  --set console.image.repository=$$CONSOLE_REPO \
 	  --set console.image.tag=$$CONSOLE_TAG \
+	  --set console.auth.username=$(KAFSCALE_UI_USERNAME) \
+	  --set console.auth.password=$(KAFSCALE_UI_PASSWORD) \
 	  --set operator.etcdEndpoints[0]=
 	@OPERATOR_DEPLOY=$$(kubectl -n $(KAFSCALE_DEMO_NAMESPACE) get deployments -l app.kubernetes.io/component=operator -o jsonpath='{.items[0].metadata.name}'); \
 	kubectl -n $(KAFSCALE_DEMO_NAMESPACE) set env deployment/$$OPERATOR_DEPLOY \

--- a/addons/processors/iceberg-processor/cmd/processor/main.go
+++ b/addons/processors/iceberg-processor/cmd/processor/main.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/novatechflow/kafscale/addons/processors/iceberg-processor/internal/config"
@@ -58,5 +59,17 @@ func envOrDefault(key, fallback string) string {
 	if value := os.Getenv(key); value != "" {
 		return value
 	}
+	warnDefaultEnv(key, fallback)
 	return fallback
+}
+
+func warnDefaultEnv(key, fallback string) {
+	if !isProdEnv() {
+		return
+	}
+	log.Printf("using default for unset env %s=%s", key, fallback)
+}
+
+func isProdEnv() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("KAFSCALE_ENV")), "prod")
 }

--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -56,7 +56,19 @@ func envOrDefault(key, fallback string) string {
 	if val := os.Getenv(key); val != "" {
 		return val
 	}
+	warnDefaultEnv(key, fallback)
 	return fallback
+}
+
+func warnDefaultEnv(key, fallback string) {
+	if !isProdEnv() {
+		return
+	}
+	log.Printf("using default for unset env %s=%s", key, fallback)
+}
+
+func isProdEnv() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("KAFSCALE_ENV")), "prod")
 }
 
 func buildMetadataStore(ctx context.Context) (metadata.Store, error) {

--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -104,6 +104,7 @@ func envOrDefault(key, fallback string) string {
 	if val := os.Getenv(key); val != "" {
 		return val
 	}
+	warnDefaultEnv(key, fallback)
 	return fallback
 }
 
@@ -113,6 +114,17 @@ func parseDurationEnv(key string) (time.Duration, error) {
 		return 0, nil
 	}
 	return time.ParseDuration(val)
+}
+
+func warnDefaultEnv(key, fallback string) {
+	if !isProdEnv() {
+		return
+	}
+	log.Printf("using default for unset env %s=%s", key, fallback)
+}
+
+func isProdEnv() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("KAFSCALE_ENV")), "prod")
 }
 
 func buildMetadataStore(ctx context.Context) (metadata.Store, error) {

--- a/pkg/operator/cluster_controller.go
+++ b/pkg/operator/cluster_controller.go
@@ -148,7 +148,6 @@ func (r *ClusterReconciler) brokerContainer(cluster *kafscalev1alpha1.KafscaleCl
 		{Name: "KAFSCALE_ETCD_ENDPOINTS", Value: strings.Join(endpoints, ",")},
 		{Name: "KAFSCALE_BROKER_HOST", Value: brokerHost},
 		{Name: "KAFSCALE_BROKER_PORT", Value: fmt.Sprintf("%d", brokerPort)},
-		{Name: "KAFSCALE_BROKER_ADDR", Value: ":9092"},
 		{Name: "KAFSCALE_METRICS_ADDR", Value: ":9093"},
 	}
 	if strings.TrimSpace(cluster.Spec.S3.Endpoint) != "" {


### PR DESCRIPTION

## Summary
- log when defaults are used if `KAFSCALE_ENV=prod` (broker, console, mcp, iceberg processor)
- set console auth defaults in `make demo-platform`
- stop overriding broker advertised host/port via `KAFSCALE_BROKER_ADDR`

## Motivation
Production should never silently fall back to defaults; logging makes it visible and easier to harden configs. The demo platform also needs UI creds and correct broker advertising.

## Testing

- [x] `go test ./...`