### PR TITLE
fix: bump sql-processor build image to go 1.24

### DIFF
--- a/addons/processors/sql-processor/Dockerfile
+++ b/addons/processors/sql-processor/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22-alpine AS build
+FROM golang:1.24-alpine AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod \


### PR DESCRIPTION
release build fix