### PR TITLE
fix per-group authz and proxy protocol parsing

### DIFF
--- a/pkg/broker/proxyproto.go
+++ b/pkg/broker/proxyproto.go
@@ -74,6 +74,9 @@ func parseProxyV1(br *bufio.Reader) (*ProxyInfo, error) {
 		return nil, err
 	}
 	parts := bytes.Fields([]byte(line))
+	if len(parts) >= 2 && bytes.Equal(bytes.ToUpper(parts[1]), []byte("UNKNOWN")) {
+		return &ProxyInfo{Local: true}, nil
+	}
 	if len(parts) < 6 {
 		return nil, fmt.Errorf("proxy v1 header malformed")
 	}

--- a/pkg/broker/proxyproto_test.go
+++ b/pkg/broker/proxyproto_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Alexander Alten (novatechflow), NovaTechflow (novatechflow.com).
+// This project is supported and financed by Scalytics, Inc. (www.scalytics.io).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package broker
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+)
+
+func TestProxyProtocolV1Unknown(t *testing.T) {
+	conn, peer := net.Pipe()
+	defer conn.Close()
+	defer peer.Close()
+
+	payload := []byte("PROXY UNKNOWN\r\nping")
+	go func() {
+		_, _ = peer.Write(payload)
+	}()
+
+	wrapped, info, err := ReadProxyProtocol(conn)
+	if err != nil {
+		t.Fatalf("ReadProxyProtocol: %v", err)
+	}
+	if info == nil || !info.Local {
+		t.Fatalf("expected local proxy info, got %+v", info)
+	}
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(wrapped, buf); err != nil {
+		t.Fatalf("read payload: %v", err)
+	}
+	if !bytes.Equal(buf, []byte("ping")) {
+		t.Fatalf("unexpected payload %q", string(buf))
+	}
+}
+
+func TestProxyProtocolV2Local(t *testing.T) {
+	conn, peer := net.Pipe()
+	defer conn.Close()
+	defer peer.Close()
+
+	header := append([]byte{}, proxyV2Signature...)
+	header = append(header, 0x20)       // v2 + LOCAL
+	header = append(header, 0x00)       // UNSPEC
+	header = append(header, 0x00, 0x00) // length 0
+	payload := append(header, []byte("pong")...)
+
+	go func() {
+		_, _ = peer.Write(payload)
+	}()
+
+	wrapped, info, err := ReadProxyProtocol(conn)
+	if err != nil {
+		t.Fatalf("ReadProxyProtocol: %v", err)
+	}
+	if info == nil || !info.Local {
+		t.Fatalf("expected local proxy info, got %+v", info)
+	}
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(wrapped, buf); err != nil {
+		t.Fatalf("read payload: %v", err)
+	}
+	if !bytes.Equal(buf, []byte("pong")) {
+		t.Fatalf("unexpected payload %q", string(buf))
+	}
+}


### PR DESCRIPTION
## Summary
Fixes per‑group authorization semantics for DescribeGroups/DeleteGroups, accepts PROXY v1 `UNKNOWN` as valid, and adds targeted tests for mixed allow/deny and PROXY protocol parsing. Also adds a small integration-style ACL test that uses proxy‑derived principals.

## Changes
- **Per‑group authz**: DescribeGroups/DeleteGroups now evaluate each group independently and return mixed results instead of all‑or‑nothing.
- **PROXY v1 UNKNOWN**: Treated as valid (local/no identity) rather than malformed.
- **Tests**:
  - Mixed allow/deny for DescribeGroups + DeleteGroups.
  - PROXY v1 UNKNOWN + PROXY v2 LOCAL parsing.
  - ACL allow via proxy‑derived principal for Produce.

## Tests
- `go test ./cmd/broker -run ACL`
- `go test ./pkg/broker -run ProxyProtocol`
- `make test-acl` (runs `KAFSCALE_E2E=1 go test -tags=e2e ./test/e2e -run TestACLsE2E`)

## Notes
- PROXY v2 LOCAL connections are accepted with no identity; ensure LB health checks don’t rely on ACL‑protected operations.
