### PR TITLE
release: prep v1.5.0

### DIFF
--- a/addons/processors/iceberg-processor/deploy/helm/iceberg-processor/Chart.yaml
+++ b/addons/processors/iceberg-processor/deploy/helm/iceberg-processor/Chart.yaml
@@ -17,5 +17,5 @@ apiVersion: v2
 name: iceberg-processor
 description: Storage-native Iceberg processor for Kafscale segments
 type: application
-version: 0.1.2
-appVersion: "v1.4.2"
+version: 0.1.0
+appVersion: "v1.5.0"

--- a/addons/processors/iceberg-processor/go.mod
+++ b/addons/processors/iceberg-processor/go.mod
@@ -3,7 +3,7 @@ module github.com/KafScale/platform/addons/processors/iceberg-processor
 go 1.25.2
 
 require (
-	github.com/KafScale/platform v1.4.2
+	github.com/KafScale/platform v1.5.0
 	github.com/apache/arrow-go/v18 v18.4.1
 	github.com/apache/iceberg-go v0.4.0
 	github.com/aws/aws-sdk-go-v2 v1.41.1

--- a/addons/processors/skeleton/deploy/helm/skeleton-processor/Chart.yaml
+++ b/addons/processors/skeleton/deploy/helm/skeleton-processor/Chart.yaml
@@ -17,5 +17,5 @@ apiVersion: v2
 name: skeleton-processor
 description: Storage-native processor skeleton for Kafscale segments
 type: application
-version: 0.1.2
-appVersion: "v1.4.2"
+version: 0.1.0
+appVersion: "v1.5.0"

--- a/addons/processors/sql-processor/deploy/helm/sql-processor/Chart.yaml
+++ b/addons/processors/sql-processor/deploy/helm/sql-processor/Chart.yaml
@@ -17,5 +17,5 @@ apiVersion: v2
 name: sql-processor
 description: SQL processor for querying Kafscale segments in S3
 type: application
-version: 0.1.2
-appVersion: "v1.4.2"
+version: 0.1.0
+appVersion: "v1.5.0"

--- a/deploy/helm/kafscale/Chart.yaml
+++ b/deploy/helm/kafscale/Chart.yaml
@@ -19,5 +19,5 @@ description: Helm chart for the Kafscale operator and console
 home: https://github.com/KafScale/platform
 icon: https://raw.githubusercontent.com/KafScale/platform/main/docs/assets/icon.png
 type: application
-version: 0.3.2
-appVersion: "v1.4.2"
+version: 0.4.0
+appVersion: "v1.5.0"

--- a/docs/releases/v1.5.0.md
+++ b/docs/releases/v1.5.0.md
@@ -1,0 +1,42 @@
+<!--
+Copyright 2026 Alexander Alten (novatechflow), NovaTechflow (novatechflow.com).
+This project is supported and financed by Scalytics, Inc. (www.scalytics.io).
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# v1.5.0
+
+Release date: 2026-01-29
+
+## Highlights
+
+- Promoted auth/ACL v1.5 capabilities with wiring and coverage updates.
+- Hardened proxy protocol parsing and per-group authorization behavior.
+- Refined processor packaging and build alignment for the 1.5 release series.
+
+## Bug fixes
+
+- Fixed per-group authorization checks and proxy protocol parsing edge cases.
+- Hardened proxy protocol handling to reduce malformed input exposure.
+- Tidied the Iceberg processor module metadata.
+
+## Maintenance
+
+- Bumped controller-runtime and GitHub Actions tooling (checkout, CodeQL).
+- Updated SQL processor build image baseline to Go 1.24.
+- Bumped Helm chart versions for core and processor charts to align with v1.5.0.
+
+## Security fixes
+
+- No known runtime vulnerabilities were fixed in this release.


### PR DESCRIPTION
## Summary

chore: v1.5 release notes and bump 

## Testing

- [ ] `go test ./...`
- [ ] `make test-produce-consume` (broker changes)
- [ ] `make test-consumer-group` (group changes)

## Checklist

- [ ] Added/updated unit tests for new logic
- [ ] Added/updated e2e coverage for bug fixes
- [ ] Added license headers to new files
