### PR TITLE
fix: install git in iceberg processor build

### DIFF
--- a/addons/processors/iceberg-processor/Dockerfile
+++ b/addons/processors/iceberg-processor/Dockerfile
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 FROM golang:1.25-alpine AS build
+RUN apk add --no-cache git
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod \


### PR DESCRIPTION
## Summary
- Install git in the iceberg-processor build stage so go mod download can resolve tagged modules

## Testing
- Not run (Docker build failure in CI was due to missing git)
