### PR TITLE
fix: update iceberg processor go.sum for v1.5.0

### DIFF
--- a/addons/processors/iceberg-processor/go.sum
+++ b/addons/processors/iceberg-processor/go.sum
@@ -68,6 +68,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0/go.mod h1:cSgYe11MCNYunTnRXrKiR/tHc0eoKjICUuWpNZoVCOo=
 github.com/KafScale/platform v1.4.2 h1:se8dIXEILnsIpY7VkqOE3UPEVGhohVZDTZUAdrq+bLE=
 github.com/KafScale/platform v1.4.2/go.mod h1:8HBfHD7GBslKj+1ymFt9BSsqOC2mAItrFBmYJjFIMhY=
+github.com/KafScale/platform v1.5.0 h1:2hZNeNG6nXN+XB6Wx/tSeKhyORcEhJe+ZfAGmJb0rz8=
+github.com/KafScale/platform v1.5.0/go.mod h1:H6eTVqlZ7baK+b1kQgiRkdsPY85VA2XVUj+twtzKZC4=
 github.com/MarvinJWendt/testza v0.1.0/go.mod h1:7AxNvlfeHP7Z/hDQ5JtE3OKYT3XFUeLCDE2DQninSqs=
 github.com/MarvinJWendt/testza v0.2.1/go.mod h1:God7bhG8n6uQxwdScay+gjm9/LnO4D3kkcZX4hv9Rp8=
 github.com/MarvinJWendt/testza v0.2.8/go.mod h1:nwIcjmr0Zz+Rcwfh3/4UhBp7ePKVhuBExvZqnKYWlII=


### PR DESCRIPTION
## Summary
- Add the missing go.sum entry for github.com/KafScale/platform@v1.5.0 used by the iceberg processor build

## Testing
- Not run (checksum update only)
