### PR TITLE
fix: arm64 images contain amd64 binaries due to hardcoded TARGETARCH default

### DIFF
--- a/deploy/docker/broker.Dockerfile
+++ b/deploy/docker/broker.Dockerfile
@@ -3,8 +3,8 @@
 ARG GO_VERSION=1.25.2
 FROM golang:${GO_VERSION}-alpine@sha256:06cdd34bd531b810650e47762c01e025eb9b1c7eadd191553b91c9f2d549fae8 AS builder
 
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /src
 RUN apk add --no-cache git ca-certificates

--- a/deploy/docker/console.Dockerfile
+++ b/deploy/docker/console.Dockerfile
@@ -3,8 +3,8 @@
 ARG GO_VERSION=1.25.2
 FROM golang:${GO_VERSION}-alpine@sha256:06cdd34bd531b810650e47762c01e025eb9b1c7eadd191553b91c9f2d549fae8 AS builder
 
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 WORKDIR /src
 RUN apk add --no-cache git ca-certificates
 

--- a/deploy/docker/e2e-client.Dockerfile
+++ b/deploy/docker/e2e-client.Dockerfile
@@ -3,8 +3,8 @@
 ARG GO_VERSION=1.25.2
 FROM golang:${GO_VERSION}-alpine@sha256:06cdd34bd531b810650e47762c01e025eb9b1c7eadd191553b91c9f2d549fae8 AS builder
 
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /src
 RUN apk add --no-cache git ca-certificates

--- a/deploy/docker/mcp.Dockerfile
+++ b/deploy/docker/mcp.Dockerfile
@@ -3,8 +3,8 @@
 ARG GO_VERSION=1.25.2
 FROM golang:${GO_VERSION}-alpine@sha256:06cdd34bd531b810650e47762c01e025eb9b1c7eadd191553b91c9f2d549fae8 AS builder
 
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 WORKDIR /src
 RUN apk add --no-cache git ca-certificates
 

--- a/deploy/docker/operator.Dockerfile
+++ b/deploy/docker/operator.Dockerfile
@@ -3,8 +3,8 @@
 ARG GO_VERSION=1.25.2
 FROM golang:${GO_VERSION}-alpine@sha256:06cdd34bd531b810650e47762c01e025eb9b1c7eadd191553b91c9f2d549fae8 AS builder
 
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /src
 RUN apk add --no-cache git ca-certificates

--- a/deploy/docker/proxy.Dockerfile
+++ b/deploy/docker/proxy.Dockerfile
@@ -3,8 +3,8 @@
 ARG GO_VERSION=1.25.2
 FROM golang:${GO_VERSION}-alpine@sha256:06cdd34bd531b810650e47762c01e025eb9b1c7eadd191553b91c9f2d549fae8 AS builder
 
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /src
 RUN apk add --no-cache git ca-certificates


### PR DESCRIPTION
## Summary

Just tried to deploy this on an ARM machine and there was a amd64 binary inside the docker image. 

Per [docker/buildx#510](https://github.com/docker/buildx/issues/510) explicit defaults for Dockerfile
platform args shadow the values that buildx injects via --platform.
This causes every platform variant to compile an amd64 binary,
regardless of the target platform.

## Solution

Just don't specify a default.