### PR TITLE
cleanup: remove minio defaults from broker, pass through operator env vars

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -51,12 +51,7 @@ const (
 	defaultKafkaPort      = 19092
 	defaultMetricsAddr    = ":19093"
 	defaultControlAddr    = ":19094"
-	defaultMinioBucket    = "kafscale"
-	defaultMinioRegion    = "us-east-1"
-	defaultMinioEndpoint  = "http://127.0.0.1:9000"
-	defaultMinioAccessKey = "minioadmin"
-	defaultMinioSecretKey  = "minioadmin"
-	defaultS3Concurrency   = 64
+	defaultS3Concurrency = 64
 	brokerVersion          = "dev"
 )
 
@@ -2145,7 +2140,7 @@ func main() {
 }
 
 func buildS3Client(ctx context.Context, logger *slog.Logger) storage.S3Client {
-	writeCfg, readCfg, useMemory, usingDefaultMinio, credsProvided, useReadReplica := buildS3ConfigsFromEnv()
+	writeCfg, readCfg, useMemory, credsProvided, useReadReplica := buildS3ConfigsFromEnv()
 	if useMemory {
 		logger.Info("using in-memory S3 client", "env", "KAFSCALE_USE_MEMORY_S3=1")
 		return storage.NewMemoryS3Client()
@@ -2162,7 +2157,7 @@ func buildS3Client(ctx context.Context, logger *slog.Logger) storage.S3Client {
 		os.Exit(1)
 	}
 
-	logger.Info("using AWS-compatible S3 client", "bucket", writeCfg.Bucket, "region", writeCfg.Region, "endpoint", writeCfg.Endpoint, "force_path_style", writeCfg.ForcePathStyle, "kms_configured", writeCfg.KMSKeyARN != "", "default_minio", usingDefaultMinio, "credentials_provided", credsProvided)
+	logger.Info("using AWS-compatible S3 client", "bucket", writeCfg.Bucket, "region", writeCfg.Region, "endpoint", writeCfg.Endpoint, "force_path_style", writeCfg.ForcePathStyle, "kms_configured", writeCfg.KMSKeyARN != "", "credentials_provided", credsProvided)
 
 	if useReadReplica {
 		readClient, err := storage.NewS3Client(ctx, readCfg)
@@ -2177,23 +2172,18 @@ func buildS3Client(ctx context.Context, logger *slog.Logger) storage.S3Client {
 	return client
 }
 
-func buildS3ConfigsFromEnv() (storage.S3Config, storage.S3Config, bool, bool, bool, bool) {
+func buildS3ConfigsFromEnv() (storage.S3Config, storage.S3Config, bool, bool, bool) {
 	if parseEnvBool("KAFSCALE_USE_MEMORY_S3", false) {
-		return storage.S3Config{}, storage.S3Config{}, true, false, false, false
+		return storage.S3Config{}, storage.S3Config{}, true, false, false
 	}
-	writeBucket := envOrDefault("KAFSCALE_S3_BUCKET", defaultMinioBucket)
-	writeRegion := envOrDefault("KAFSCALE_S3_REGION", defaultMinioRegion)
-	writeEndpoint := envOrDefault("KAFSCALE_S3_ENDPOINT", defaultMinioEndpoint)
-	forcePathStyle := parseEnvBool("KAFSCALE_S3_PATH_STYLE", true)
+	writeBucket := os.Getenv("KAFSCALE_S3_BUCKET")
+	writeRegion := os.Getenv("KAFSCALE_S3_REGION")
+	writeEndpoint := os.Getenv("KAFSCALE_S3_ENDPOINT")
+	forcePathStyle := parseEnvBool("KAFSCALE_S3_PATH_STYLE", writeEndpoint != "")
 	kmsARN := os.Getenv("KAFSCALE_S3_KMS_ARN")
-	usingDefaultMinio := writeBucket == defaultMinioBucket && writeRegion == defaultMinioRegion && writeEndpoint == defaultMinioEndpoint
 	accessKey := os.Getenv("KAFSCALE_S3_ACCESS_KEY")
 	secretKey := os.Getenv("KAFSCALE_S3_SECRET_KEY")
 	sessionToken := os.Getenv("KAFSCALE_S3_SESSION_TOKEN")
-	if accessKey == "" && secretKey == "" && usingDefaultMinio {
-		accessKey = defaultMinioAccessKey
-		secretKey = defaultMinioSecretKey
-	}
 	credsProvided := accessKey != "" && secretKey != ""
 	s3Concurrency := parseEnvInt("KAFSCALE_S3_CONCURRENCY", defaultS3Concurrency)
 	writeCfg := storage.S3Config{
@@ -2232,7 +2222,7 @@ func buildS3ConfigsFromEnv() (storage.S3Config, storage.S3Config, bool, bool, bo
 		KMSKeyARN:       kmsARN,
 		MaxConnections:  s3Concurrency,
 	}
-	return writeCfg, readCfg, false, usingDefaultMinio, credsProvided, useReadReplica
+	return writeCfg, readCfg, false, credsProvided, useReadReplica
 }
 
 func buildConnContextFunc(logger *slog.Logger) broker.ConnContextFunc {

--- a/pkg/operator/cluster_controller.go
+++ b/pkg/operator/cluster_controller.go
@@ -247,6 +247,12 @@ func (r *ClusterReconciler) brokerContainer(cluster *kafscalev1alpha1.KafscaleCl
 	if val := strings.TrimSpace(os.Getenv("KAFSCALE_PROXY_PROTOCOL")); val != "" {
 		env = append(env, corev1.EnvVar{Name: "KAFSCALE_PROXY_PROTOCOL", Value: val})
 	}
+	if val := strings.TrimSpace(os.Getenv("KAFSCALE_LOG_LEVEL")); val != "" {
+		env = append(env, corev1.EnvVar{Name: "KAFSCALE_LOG_LEVEL", Value: val})
+	}
+	if val := strings.TrimSpace(os.Getenv("KAFSCALE_TRACE_KAFKA")); val != "" {
+		env = append(env, corev1.EnvVar{Name: "KAFSCALE_TRACE_KAFKA", Value: val})
+	}
 	var envFrom []corev1.EnvFromSource
 	if cluster.Spec.S3.CredentialsSecretRef != "" {
 		envFrom = append(envFrom, corev1.EnvFromSource{


### PR DESCRIPTION
The broker had hardcoded minio defaults (bucket `kafscale`, endpoint `http://127.0.0.1:9000`, credentials `minioadmin:minioadmin`). When S3 env vars were empty or missing, it silently fell back to these, even in real deployments.

This caused a problem when deploying to AWS: setting region and bucket but not endpoint (correct for real S3) still resulted in the endpoint defaulting to `http://127.0.0.1:9000`. 

The better default is AWS, the SDK can infer the endpoint from the region. A custom self-hosted endpoint can never be inferred, so that's what you should have to opt into explicitly, that's what people are used to from tools relying on the AWS SDK.

The [minio/minio](https://github.com/minio/minio) repo is now archived. All other code in this repo (Makefile, e2e tests, demo scripts) already passes S3 config explicitly, nothing depended on these minio broker defaults that can be explicitly set if needed.

This also passes through a few env vars that the operator wasn't forwarding to broker and etcd containers.