### PR TITLE
website update

### DIFF
--- a/_docs/configuration.md
+++ b/_docs/configuration.md
@@ -245,6 +245,8 @@ KAFSCALE_ETCD_KEY_FILE=/etc/kafscale/etcd/tls.key
 KAFSCALE_ETCD_CA_FILE=/etc/kafscale/etcd/ca.crt
 ```
 
+Topic recovery via `kafscale-cli restore` uses the same `KAFSCALE_ETCD_*` settings for topic metadata, partition state, and recovered next offsets.
+
 ---
 
 ## Proxy Configuration

--- a/_docs/faq.md
+++ b/_docs/faq.md
@@ -309,6 +309,21 @@ spec:
       interval: 1h
 ```
 
+### Can I restore a topic to an earlier point in time?
+
+Yes, but the supported model is **DR-side restore into a new topic**, not in-place rollback on the primary cluster.
+
+KafScale can recover a topic by copying immutable `.kfs` segment/index pairs up to a chosen timestamp into a fresh target topic:
+
+```bash
+kafscale-cli restore \
+  --topic orders \
+  --target-topic orders-restore-20260513 \
+  --to 2026-05-13T14:23:00Z
+```
+
+This is segment-granular rather than record-exact PITR. The safer workflow is restore, validate, and then cut consumers over deliberately.
+
 ### How do I monitor KafScale?
 
 Brokers expose Prometheus metrics on port 9093. Key metrics:

--- a/_docs/operations.md
+++ b/_docs/operations.md
@@ -403,6 +403,27 @@ When the operator manages etcd, each pod runs restore init containers before etc
 2. Restore container runs `etcdctl snapshot restore` if data directory is empty
 3. If no snapshot is available, etcd starts fresh
 
+### Topic recovery on the DR spine
+
+For broker topic data, KafScale supports DR-side recovery into a **new topic**. This is not in-place rollback on the primary cluster.
+
+Use `kafscale-cli restore` to create a fresh target topic, copy immutable `.kfs` segment/index pairs up to a cutoff timestamp, and set the recovered topic's next offsets in etcd:
+
+```bash
+kafscale-cli restore \
+  --topic orders \
+  --target-topic orders-restore-20260513 \
+  --to 2026-05-13T14:23:00Z
+```
+
+Operational semantics:
+
+- Recovery uses the existing S3 + etcd control plane. Configure it with `KAFSCALE_S3_BUCKET`, `KAFSCALE_S3_REGION`, optional `KAFSCALE_S3_ENDPOINT` / `KAFSCALE_S3_PATH_STYLE`, and `KAFSCALE_ETCD_ENDPOINTS`.
+- The target topic must be new. KafScale refuses to restore over a topic that already has persisted segment data.
+- Recovery is **segment-granular**. The cutoff is based on immutable segment creation time, then KafScale copies contiguous segment/index pairs up to the first segment created after that timestamp.
+- Offsets are preserved inside the restored topic so replay, validation, and controlled cutover can happen without rewriting the source topic.
+- The intended workflow is restore, validate, then cut consumers or downstream jobs over deliberately.
+
 ### Consumer Offsets After Restore
 
 Etcd restores recover committed consumer offsets. If a consumer has **no committed offsets**, it may start at the end and see zero records even though data exists in S3. In production:


### PR DESCRIPTION
<!--
Copyright 2025 Alexander Alten (novatechflow), NovaTechflow (novatechflow.com).
This project is supported and financed by Scalytics, Inc. (www.scalytics.io).

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

## Summary
- document DR-side topic recovery in the operations guide
- add an FAQ entry for topic restore semantics
- note that `kafscale-cli restore` reuses the existing etcd config settings

