### PR TITLE
ci: build sql processor with go 1.25

### DIFF
--- a/addons/processors/sql-processor/Dockerfile
+++ b/addons/processors/sql-processor/Dockerfile
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.24-alpine AS build
+ARG GO_VERSION=1.25.2
+FROM golang:${GO_VERSION}-alpine@sha256:06cdd34bd531b810650e47762c01e025eb9b1c7eadd191553b91c9f2d549fae8 AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod \


### PR DESCRIPTION
## Summary
- update the sql processor Docker builder image from Go 1.24 to Go 1.25.2
- align the Docker build environment with addons/processors/sql-processor/go.mod

## Evidence
- release-image run 26825188813 failed in the sql-processor image build
- the job log reported: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)

## Testing
- verified the Dockerfile now matches the module Go version requirement
