### PR TITLE
ci: build iceberg processor against v1.6.0

### DIFF
--- a/addons/processors/iceberg-processor/Dockerfile
+++ b/addons/processors/iceberg-processor/Dockerfile
@@ -26,7 +26,7 @@ RUN if [ "${USE_LOCAL_PLATFORM}" != "1" ]; then \
       go mod edit -dropreplace github.com/KafScale/platform || true; \
     fi
 RUN if [ "${USE_LOCAL_PLATFORM}" != "1" ]; then \
-      go mod download github.com/KafScale/platform@v1.5.0 || true; \
+      go mod download github.com/KafScale/platform@v1.6.0 || true; \
     fi
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \

--- a/addons/processors/iceberg-processor/go.mod
+++ b/addons/processors/iceberg-processor/go.mod
@@ -3,7 +3,7 @@ module github.com/KafScale/platform/addons/processors/iceberg-processor
 go 1.25.2
 
 require (
-	github.com/KafScale/platform v1.5.0
+	github.com/KafScale/platform v1.6.0
 	github.com/apache/arrow-go/v18 v18.4.1
 	github.com/apache/iceberg-go v0.4.0
 	github.com/aws/aws-sdk-go-v2 v1.41.5


### PR DESCRIPTION
## Summary
- bump the iceberg processor platform module requirement from v1.5.0 to v1.6.0
- update the release-build Dockerfile preload to download github.com/KafScale/platform@v1.6.0

## Evidence
- release-image run 26826141334 failed in the iceberg processor image build
- the job log reported: no required module provides package github.com/KafScale/platform/pkg/lfs
- the addon still required github.com/KafScale/platform v1.5.0 while importing pkg/lfs, which was added after v1.5.0

## Testing
- verified the addon go.mod and Dockerfile now reference v1.6.0 consistently for the release-image path
