### PR TITLE
fix(operator): etcd compaction, maintenance jobs, and alerts

### DIFF
--- a/deploy/helm/kafscale/templates/operator-prometheusrule.yaml
+++ b/deploy/helm/kafscale/templates/operator-prometheusrule.yaml
@@ -51,4 +51,20 @@ spec:
           annotations:
             summary: Kafscale snapshot has never succeeded
             description: No successful etcd snapshots recorded yet for cluster {{`{{ $labels.cluster }}`}}.
+        - alert: KafscaleEtcdBackendSizeHigh
+          expr: kafscale_operator_etcd_db_size_high == 1
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: Kafscale etcd backend size is high
+            description: Managed etcd backend size exceeded the maintenance threshold for cluster {{`{{ $labels.cluster }}`}}.
+        - alert: KafscaleEtcdNOSPACE
+          expr: kafscale_operator_etcd_nospace_alarm == 1
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: Kafscale etcd NOSPACE alarm active
+            description: Managed etcd has an active NOSPACE alarm for cluster {{`{{ $labels.cluster }}`}}. Produce may fail until maintenance runs.
 {{- end }}

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -82,8 +82,14 @@ Operator metrics are exported by the controller runtime metrics server.
 | `kafscale_operator_etcd_snapshot_stale` | Gauge | `cluster` | 1 when the snapshot age exceeds the staleness threshold. |
 | `kafscale_operator_etcd_snapshot_success` | Gauge | `cluster` | 1 if at least one successful snapshot was recorded. |
 | `kafscale_operator_etcd_snapshot_access_ok` | Gauge | `cluster` | 1 if the snapshot bucket preflight succeeds. |
+| `kafscale_operator_etcd_db_total_size_bytes` | Gauge | `cluster`, `member` | Physical etcd backend size per managed member. |
+| `kafscale_operator_etcd_db_in_use_bytes` | Gauge | `cluster`, `member` | Logical in-use etcd backend size per managed member. |
+| `kafscale_operator_etcd_db_size_high` | Gauge | `cluster` | 1 when any member exceeds the maintenance size threshold. |
+| `kafscale_operator_etcd_nospace_alarm` | Gauge | `cluster` | 1 when managed etcd has an active NOSPACE alarm. |
 
 The `cluster` label uses `namespace/name`.
+
+Helm can emit `KafscaleEtcdBackendSizeHigh` and `KafscaleEtcdNOSPACE` PrometheusRule alerts when `operator.metrics.prometheusRule.enabled=true`.
 
 ## Grafana Dashboard
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -190,6 +190,14 @@ If no etcd endpoints are supplied, the operator will provision a 3-node etcd Sta
 - Enable snapshot backups to a dedicated S3 bucket and retain at least 7 days of snapshots.
 - Monitor leader changes, fsync latency, and disk usage; alert on slow or flapping members.
 
+The operator tunes managed etcd automatically:
+
+- In-process periodic compaction (5m retention) and a 4 GiB backend quota on the etcd StatefulSet.
+- `{cluster}-etcd-maintenance` CronJob (every 6h): per-member defrag and NOSPACE alarm disarm.
+- `{cluster}-etcd-maintenance-check` CronJob (every 15m): runs maintenance only when backend size crosses 75% of quota or a NOSPACE alarm is active.
+
+Override schedules and thresholds via the operator etcd env vars listed below.
+
 ### Etcd Endpoint Resolution
 
 The operator resolves etcd endpoints in this order:
@@ -283,6 +291,13 @@ Recommended operator alerting (when using Prometheus Operator):
 - `KAFSCALE_OPERATOR_ETCD_STORAGE_SIZE` – PVC size for managed etcd (default `10Gi`).
 - `KAFSCALE_OPERATOR_ETCD_STORAGE_CLASS` – StorageClass for managed etcd PVCs.
 - `KAFSCALE_OPERATOR_ETCD_STORAGE_MEMORY` – Use in-memory `emptyDir` for etcd data (`1` to enable, test/dev only).
+- `KAFSCALE_OPERATOR_ETCD_AUTO_COMPACTION_MODE` – Managed etcd compaction mode (`periodic` or `revision`; default `periodic`).
+- `KAFSCALE_OPERATOR_ETCD_AUTO_COMPACTION_RETENTION` – Compaction retention (`5m` for periodic mode; default `5m`).
+- `KAFSCALE_OPERATOR_ETCD_QUOTA_BACKEND_BYTES` – Managed etcd backend quota in bytes (default `4294967296`, 4 GiB).
+- `KAFSCALE_OPERATOR_ETCD_MAINTENANCE_SCHEDULE` – Baseline maintenance CronJob schedule (default `0 */6 * * *`).
+- `KAFSCALE_OPERATOR_ETCD_MAINTENANCE_CHECK_SCHEDULE` – Reactive size-check CronJob schedule (default `*/15 * * * *`).
+- `KAFSCALE_OPERATOR_ETCD_MAINTENANCE_ENABLED` – Enable maintenance CronJobs (`0`/`false` to disable; enabled by default).
+- `KAFSCALE_OPERATOR_ETCD_MAINTENANCE_SIZE_THRESHOLD_PCT` – Backend size threshold percent of quota before reactive maintenance runs (default `75`).
 - `KAFSCALE_OPERATOR_ETCD_SNAPSHOT_BUCKET` – Override snapshot bucket (default: `kafscale-etcd-<namespace>-<cluster>`).
 - `KAFSCALE_OPERATOR_ETCD_SNAPSHOT_PREFIX` – Snapshot prefix (default `etcd-snapshots`).
 - `KAFSCALE_OPERATOR_ETCD_SNAPSHOT_SCHEDULE` – Cron schedule for snapshots (default `0 * * * *`).

--- a/pkg/metadata/etcd_store.go
+++ b/pkg/metadata/etcd_store.go
@@ -379,9 +379,9 @@ func (s *EtcdStore) CreatePartitions(ctx context.Context, topic string, partitio
 	if err := s.metadata.CreatePartitions(ctx, topic, partitionCount); err != nil {
 		return err
 	}
-	if err := s.persistSnapshot(ctx); err != nil {
-		return err
-	}
+	// Read new partition metadata before persisting. The snapshot watcher can
+	// refresh in-memory state from etcd while persistSnapshot runs, so a later
+	// Metadata call may see a stale partition count and panic on index access.
 	updated, err := s.metadata.Metadata(ctx, []string{topic})
 	if err != nil {
 		return err
@@ -389,8 +389,14 @@ func (s *EtcdStore) CreatePartitions(ctx context.Context, topic string, partitio
 	if len(updated.Topics) == 0 || updated.Topics[0].ErrorCode != 0 {
 		return ErrUnknownTopic
 	}
-	for i := current; i < partitionCount; i++ {
-		part := updated.Topics[0].Partitions[i]
+	newPartitions := updated.Topics[0].Partitions[current:partitionCount]
+	if int32(len(newPartitions)) != partitionCount-current {
+		return fmt.Errorf("metadata: expected %d new partitions, got %d", partitionCount-current, len(newPartitions))
+	}
+	if err := s.persistSnapshot(ctx); err != nil {
+		return err
+	}
+	for _, part := range newPartitions {
 		state := &metadatapb.PartitionState{
 			Topic:          topic,
 			Partition:      part.Partition,

--- a/pkg/operator/cluster_controller.go
+++ b/pkg/operator/cluster_controller.go
@@ -78,6 +78,8 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 	r.populateEtcdSnapshotStatus(ctx, &cluster, etcdResolution)
+	r.pollManagedEtcdHealth(ctx, &cluster, etcdResolution)
+	r.populateEtcdMaintenanceStatus(ctx, &cluster, etcdResolution)
 	if err := r.deleteLegacyBrokerDeployment(ctx, &cluster); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -550,6 +552,45 @@ func (r *ClusterReconciler) populateEtcdSnapshotStatus(ctx context.Context, clus
 		Type:               "EtcdSnapshot",
 		Status:             metav1.ConditionTrue,
 		Reason:             "SnapshotHealthy",
+		Message:            message,
+		LastTransitionTime: metav1.NewTime(now),
+	})
+}
+
+func (r *ClusterReconciler) populateEtcdMaintenanceStatus(ctx context.Context, cluster *kafscalev1alpha1.KafscaleCluster, resolution EtcdResolution) {
+	now := time.Now()
+	if !resolution.Managed || !etcdMaintenanceEnabled() {
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:               "EtcdMaintenance",
+			Status:             metav1.ConditionFalse,
+			Reason:             "MaintenanceNotManaged",
+			Message:            "Etcd maintenance jobs are not managed for this cluster.",
+			LastTransitionTime: metav1.NewTime(now),
+		})
+		return
+	}
+
+	cron := &batchv1.CronJob{}
+	cronKey := client.ObjectKey{Namespace: cluster.Namespace, Name: fmt.Sprintf("%s-etcd-maintenance", cluster.Name)}
+	if err := r.Client.Get(ctx, cronKey, cron); err != nil {
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:               "EtcdMaintenance",
+			Status:             metav1.ConditionFalse,
+			Reason:             "MaintenanceCronMissing",
+			Message:            "Etcd maintenance CronJob is missing.",
+			LastTransitionTime: metav1.NewTime(now),
+		})
+		return
+	}
+
+	message := "Etcd maintenance CronJobs are scheduled."
+	if cron.Status.LastSuccessfulTime != nil {
+		message = fmt.Sprintf("Last successful maintenance %s ago.", now.Sub(cron.Status.LastSuccessfulTime.Time).Round(time.Second))
+	}
+	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+		Type:               "EtcdMaintenance",
+		Status:             metav1.ConditionTrue,
+		Reason:             "MaintenanceScheduled",
 		Message:            message,
 		LastTransitionTime: metav1.NewTime(now),
 	})

--- a/pkg/operator/etcd_health.go
+++ b/pkg/operator/etcd_health.go
@@ -1,0 +1,114 @@
+// Copyright 2025 Alexander Alten (novatechflow), NovaTechflow (novatechflow.com).
+// This project is supported and financed by Scalytics, Inc. (www.scalytics.io).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	etcdserverpb "go.etcd.io/etcd/api/v3/etcdserverpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	kafscalev1alpha1 "github.com/KafScale/platform/api/v1alpha1"
+)
+
+func (r *ClusterReconciler) pollManagedEtcdHealth(ctx context.Context, cluster *kafscalev1alpha1.KafscaleCluster, resolution EtcdResolution) {
+	clusterKey := cluster.Namespace + "/" + cluster.Name
+	resetEtcdHealthMetrics(clusterKey)
+
+	if !resolution.Managed {
+		return
+	}
+
+	endpoints := managedEtcdMemberClientEndpoints(cluster)
+	if len(endpoints) == 0 {
+		return
+	}
+
+	cfg := clientv3.Config{
+		Endpoints:   endpoints,
+		DialTimeout: 3 * time.Second,
+	}
+	cli, err := clientv3.New(cfg)
+	if err != nil {
+		return
+	}
+	defer func() { _ = cli.Close() }()
+
+	pollCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	var maxDbSize int64
+	for i, ep := range endpoints {
+		member := fmt.Sprintf("etcd-%d", i)
+		status, err := cli.Maintenance.Status(pollCtx, ep)
+		if err != nil {
+			continue
+		}
+		if status.DbSize > maxDbSize {
+			maxDbSize = status.DbSize
+		}
+		operatorEtcdDbTotalSizeBytes.WithLabelValues(clusterKey, member).Set(float64(status.DbSize))
+		operatorEtcdDbInUseBytes.WithLabelValues(clusterKey, member).Set(float64(status.DbSizeInUse))
+	}
+
+	quota := etcdQuotaBackendBytes()
+	threshold := etcdMaintenanceSizeThresholdBytes(quota)
+	if maxDbSize >= threshold {
+		operatorEtcdDbSizeHigh.WithLabelValues(clusterKey).Set(1)
+	}
+
+	alarmResp, err := cli.AlarmList(pollCtx)
+	if err != nil {
+		return
+	}
+	for _, alarm := range alarmResp.Alarms {
+		if alarm.Alarm == etcdserverpb.AlarmType_NOSPACE {
+			operatorEtcdNospaceAlarm.WithLabelValues(clusterKey).Set(1)
+			return
+		}
+	}
+}
+
+func resetEtcdHealthMetrics(clusterKey string) {
+	operatorEtcdDbSizeHigh.WithLabelValues(clusterKey).Set(0)
+	operatorEtcdNospaceAlarm.WithLabelValues(clusterKey).Set(0)
+	for i := 0; i < int(defaultEtcdReplicas); i++ {
+		member := fmt.Sprintf("etcd-%d", i)
+		operatorEtcdDbTotalSizeBytes.DeleteLabelValues(clusterKey, member)
+		operatorEtcdDbInUseBytes.DeleteLabelValues(clusterKey, member)
+	}
+}
+
+func etcdMaintenanceSizeThresholdPct() int64 {
+	raw := strings.TrimSpace(os.Getenv(operatorEtcdMaintenanceSizeThresholdPctEnv))
+	if raw == "" {
+		return defaultEtcdMaintenanceSizeThresholdPct
+	}
+	parsed, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || parsed <= 0 || parsed > 100 {
+		return defaultEtcdMaintenanceSizeThresholdPct
+	}
+	return parsed
+}
+
+func etcdMaintenanceSizeThresholdBytes(quota int64) int64 {
+	return quota * etcdMaintenanceSizeThresholdPct() / 100
+}

--- a/pkg/operator/etcd_resources.go
+++ b/pkg/operator/etcd_resources.go
@@ -53,6 +53,21 @@ const (
 	operatorEtcdSnapshotProtectBucketEnv = "KAFSCALE_OPERATOR_ETCD_SNAPSHOT_PROTECT_BUCKET"
 	operatorEtcdStorageMemoryEnv         = "KAFSCALE_OPERATOR_ETCD_STORAGE_MEMORY"
 
+	// etcd space-management knobs. KafScale writes one MVCC revision per
+	// offset update (one per produce), so the store grows fast under load.
+	// These three control periodic compaction and the backend quota; all
+	// have safe defaults and only need an override on high-write clusters.
+	operatorEtcdQuotaBackendBytesEnv           = "KAFSCALE_OPERATOR_ETCD_QUOTA_BACKEND_BYTES"
+	operatorEtcdAutoCompactionRetentionEnv     = "KAFSCALE_OPERATOR_ETCD_AUTO_COMPACTION_RETENTION"
+	operatorEtcdAutoCompactionModeEnv          = "KAFSCALE_OPERATOR_ETCD_AUTO_COMPACTION_MODE"
+	operatorEtcdMaintenanceScheduleEnv         = "KAFSCALE_OPERATOR_ETCD_MAINTENANCE_SCHEDULE"
+	operatorEtcdMaintenanceCheckScheduleEnv    = "KAFSCALE_OPERATOR_ETCD_MAINTENANCE_CHECK_SCHEDULE"
+	operatorEtcdMaintenanceEnabledEnv          = "KAFSCALE_OPERATOR_ETCD_MAINTENANCE_ENABLED"
+	operatorEtcdMaintenanceSizeThresholdPctEnv = "KAFSCALE_OPERATOR_ETCD_MAINTENANCE_SIZE_THRESHOLD_PCT"
+	// Deprecated aliases kept for backward compatibility.
+	operatorEtcdDefragScheduleEnv = "KAFSCALE_OPERATOR_ETCD_DEFRAG_SCHEDULE"
+	operatorEtcdDefragEnabledEnv  = "KAFSCALE_OPERATOR_ETCD_DEFRAG_ENABLED"
+
 	defaultEtcdImage                 = "kubesphere/etcd:3.6.4-0"
 	defaultEtcdctlImage              = "ghcr.io/kafscale/kafscale-etcd-tools:dev"
 	defaultEtcdStorageSize           = "10Gi"
@@ -62,6 +77,20 @@ const (
 	defaultSnapshotSchedule          = "0 * * * *"
 	defaultSnapshotImage             = "amazon/aws-cli:2.15.0"
 	defaultSnapshotStaleAfterSeconds = 2 * 60 * 60
+
+	// 4 GiB backend quota: headroom above etcd's 2 GiB default so a write
+	// burst cannot exceed the quota between compaction cycles.
+	defaultEtcdQuotaBackendBytes = int64(4 * 1024 * 1024 * 1024)
+	// 5 minutes of retained revisions keeps recovery/audit history while the
+	// compactor keeps pace with the broker write rate.
+	defaultEtcdAutoCompactionRetention = "5m"
+	// "periodic" compacts on a wall-clock interval (the retention value);
+	// "revision" is the only other valid mode.
+	defaultEtcdAutoCompactionMode = "periodic"
+	// Maintenance CronJob: defrag + alarm disarm. One member at a time.
+	defaultEtcdMaintenanceSchedule         = "0 */6 * * *"
+	defaultEtcdMaintenanceCheckSchedule    = "*/15 * * * *"
+	defaultEtcdMaintenanceSizeThresholdPct = int64(75)
 )
 
 type EtcdResolution struct {
@@ -127,6 +156,9 @@ func reconcileEtcdResources(ctx context.Context, c client.Client, scheme *runtim
 		return err
 	}
 	if err := reconcileEtcdSnapshotCronJob(ctx, c, scheme, cluster); err != nil {
+		return err
+	}
+	if err := reconcileEtcdMaintenanceCronJobs(ctx, c, scheme, cluster); err != nil {
 		return err
 	}
 	return nil
@@ -367,25 +399,46 @@ func reconcileEtcdStatefulSet(ctx context.Context, c client.Client, scheme *runt
 				},
 			}
 		}
-		sts.Spec.Template.Spec.Containers = []corev1.Container{
-			{
-				Name:  "etcd",
-				Image: image,
-				Ports: []corev1.ContainerPort{
-					{Name: "client", ContainerPort: 2379},
-					{Name: "peer", ContainerPort: 2380},
-				},
-				Env: []corev1.EnvVar{
-					{Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"}}},
-					{Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}},
-				},
-				Command: []string{"etcd"},
-				Args:    etcdArgs(cluster),
-				VolumeMounts: []corev1.VolumeMount{
-					{Name: "data", MountPath: "/var/lib/etcd"},
-				},
+		etcdContainer := corev1.Container{
+			Name:  "etcd",
+			Image: image,
+			Ports: []corev1.ContainerPort{
+				{Name: "client", ContainerPort: 2379},
+				{Name: "peer", ContainerPort: 2380},
+			},
+			Env: []corev1.EnvVar{
+				{Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"}}},
+				{Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}},
+			},
+			Command: []string{"etcd"},
+			Args:    etcdArgs(cluster),
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: "data", MountPath: "/var/lib/etcd"},
 			},
 		}
+		// Memory-mode guard. With storage-memory mode the data dir is a tmpfs
+		// emptyDir, so every byte etcd writes (up to the backend quota) is
+		// resident node RAM. A tmpfs has no size cap of its own, so a 4 GiB
+		// quota could drive ~4 GiB of node memory and risk an OOM that takes
+		// the node down. The tmpfs allocation counts against this container's
+		// memory cgroup, so a memory limit bounds it: the kernel reclaims/kills
+		// inside the container before the node is starved. The limit is the
+		// quota plus headroom for etcd's own heap and bbolt mmap pages; the
+		// request matches the quota so the scheduler reserves real capacity.
+		// Disk-backed (PVC) mode is unchanged: bytes land on the volume, not RAM.
+		if useMemory {
+			quota := etcdQuotaBackendBytes()
+			memLimit := quota + (512 * 1024 * 1024)
+			etcdContainer.Resources = corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: *resource.NewQuantity(quota, resource.BinarySI),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: *resource.NewQuantity(memLimit, resource.BinarySI),
+				},
+			}
+		}
+		sts.Spec.Template.Spec.Containers = []corev1.Container{etcdContainer}
 		return controllerutil.SetControllerReference(cluster, sts, scheme)
 	})
 	return err
@@ -406,6 +459,18 @@ func etcdArgs(cluster *kafscalev1alpha1.KafscaleCluster) []string {
 		"--initial-cluster=" + initialCluster,
 		"--initial-cluster-state=new",
 		"--initial-cluster-token=" + cluster.Name + "-etcd",
+		// Periodic auto-compaction. KafScale writes one etcd revision per
+		// offset update (one per produce), so without compaction the DB fills
+		// to the default 2 GiB quota under load and the broker starts rejecting
+		// produce with `mvcc: database space exceeded`. Compaction reclaims
+		// revisions logically (bbolt pages become reusable). Physical reclaim
+		// and NOSPACE alarm disarm run on a separate defrag CronJob.
+		// Mode + retention + quota are env-configurable for high-write clusters.
+		"--auto-compaction-mode=" + etcdAutoCompactionMode(),
+		"--auto-compaction-retention=" + etcdAutoCompactionRetention(),
+		// Headroom above the default 2 GiB so a burst cannot exceed the quota
+		// between compactions; raises the soft cap inside etcd.
+		"--quota-backend-bytes=" + strconv.FormatInt(etcdQuotaBackendBytes(), 10),
 	}
 }
 
@@ -603,6 +668,147 @@ func reconcileEtcdSnapshotCronJob(ctx context.Context, c client.Client, scheme *
 	return err
 }
 
+func reconcileEtcdMaintenanceCronJobs(ctx context.Context, c client.Client, scheme *runtime.Scheme, cluster *kafscalev1alpha1.KafscaleCluster) error {
+	if !etcdMaintenanceEnabled() {
+		return nil
+	}
+	etcdctlImage := getEnv(operatorEtcdSnapshotEtcdctlEnv, defaultEtcdctlImage)
+	memberEndpoints := strings.Join(managedEtcdMemberClientEndpoints(cluster), ",")
+	quota := strconv.FormatInt(etcdQuotaBackendBytes(), 10)
+	thresholdPct := strconv.FormatInt(etcdMaintenanceSizeThresholdPct(), 10)
+
+	if err := reconcileEtcdMaintenanceCronJob(ctx, c, scheme, cluster, etcdMaintenanceCronSpec{
+		name:            fmt.Sprintf("%s-etcd-maintenance", cluster.Name),
+		schedule:        etcdMaintenanceSchedule(),
+		etcdctlImage:    etcdctlImage,
+		memberEndpoints: memberEndpoints,
+		quotaBytes:      quota,
+		thresholdPct:    thresholdPct,
+		checkOnly:       "0",
+		taskLabel:       "maintenance",
+	}); err != nil {
+		return err
+	}
+
+	return reconcileEtcdMaintenanceCronJob(ctx, c, scheme, cluster, etcdMaintenanceCronSpec{
+		name:            fmt.Sprintf("%s-etcd-maintenance-check", cluster.Name),
+		schedule:        etcdMaintenanceCheckSchedule(),
+		etcdctlImage:    etcdctlImage,
+		memberEndpoints: memberEndpoints,
+		quotaBytes:      quota,
+		thresholdPct:    thresholdPct,
+		checkOnly:       "1",
+		taskLabel:       "maintenance-check",
+	})
+}
+
+type etcdMaintenanceCronSpec struct {
+	name            string
+	schedule        string
+	etcdctlImage    string
+	memberEndpoints string
+	quotaBytes      string
+	thresholdPct    string
+	checkOnly       string
+	taskLabel       string
+}
+
+func reconcileEtcdMaintenanceCronJob(ctx context.Context, c client.Client, scheme *runtime.Scheme, cluster *kafscalev1alpha1.KafscaleCluster, spec etcdMaintenanceCronSpec) error {
+	cron := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{
+		Name:      spec.name,
+		Namespace: cluster.Namespace,
+	}}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, c, cron, func() error {
+		labels := etcdMaintenanceLabels(cluster, spec.taskLabel)
+		cron.Labels = labels
+		cron.Spec.Schedule = spec.schedule
+		cron.Spec.ConcurrencyPolicy = batchv1.ForbidConcurrent
+		cron.Spec.SuccessfulJobsHistoryLimit = int32Ptr(3)
+		cron.Spec.FailedJobsHistoryLimit = int32Ptr(3)
+		cron.Spec.JobTemplate.Spec.Template.Labels = labels
+		cron.Spec.JobTemplate.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
+		activeDeadline := int64(1800)
+		cron.Spec.JobTemplate.Spec.Template.Spec.ActiveDeadlineSeconds = &activeDeadline
+		cron.Spec.JobTemplate.Spec.Template.Spec.Containers = []corev1.Container{
+			{
+				Name:  "maintenance",
+				Image: spec.etcdctlImage,
+				Env: []corev1.EnvVar{
+					{Name: "ETCD_MEMBERS", Value: spec.memberEndpoints},
+					{Name: "ETCDCTL_API", Value: "3"},
+					{Name: "ETCD_QUOTA_BYTES", Value: spec.quotaBytes},
+					{Name: "THRESHOLD_PCT", Value: spec.thresholdPct},
+					{Name: "CHECK_ONLY", Value: spec.checkOnly},
+				},
+				Command: []string{"/bin/sh", "-c"},
+				Args:    []string{etcdMaintenanceShellScript()},
+			},
+		}
+		return controllerutil.SetControllerReference(cluster, cron, scheme)
+	})
+	return err
+}
+
+func etcdMaintenanceLabels(cluster *kafscalev1alpha1.KafscaleCluster, task string) map[string]string {
+	labels := etcdLabels(cluster)
+	labels["app.kubernetes.io/component"] = "etcd-maintenance"
+	labels["kafscale.io/etcd-task"] = task
+	return labels
+}
+
+func etcdMaintenanceShellScript() string {
+	return "set -euo pipefail\n" +
+		"THRESHOLD_BYTES=$(( ETCD_QUOTA_BYTES * THRESHOLD_PCT / 100 ))\n" +
+		"needs_work=0\n" +
+		"IFS=',' read -ra MEMBERS <<< \"${ETCD_MEMBERS}\"\n" +
+		"for ep in \"${MEMBERS[@]}\"; do\n" +
+		"  status_json=$(etcdctl --endpoints=\"${ep}\" endpoint status -w json 2>/dev/null || true)\n" +
+		"  if [ -z \"${status_json}\" ]; then\n" +
+		"    echo \"status unavailable for ${ep}\"\n" +
+		"    needs_work=1\n" +
+		"    continue\n" +
+		"  fi\n" +
+		"  db_size=$(printf '%s' \"${status_json}\" | sed -n 's/.*\"dbSize\":\\([0-9]*\\).*/\\1/p' | head -1)\n" +
+		"  db_size=${db_size:-0}\n" +
+		"  echo \"member ${ep} dbSize=${db_size} threshold=${THRESHOLD_BYTES}\"\n" +
+		"  if [ \"${db_size}\" -ge \"${THRESHOLD_BYTES}\" ]; then\n" +
+		"    needs_work=1\n" +
+		"  fi\n" +
+		"  if etcdctl --endpoints=\"${ep}\" alarm list 2>/dev/null | grep -q NOSPACE; then\n" +
+		"    echo \"NOSPACE alarm on ${ep}\"\n" +
+		"    needs_work=1\n" +
+		"  fi\n" +
+		"done\n" +
+		"if [ \"${CHECK_ONLY}\" = \"1\" ] && [ \"${needs_work}\" -eq 0 ]; then\n" +
+		"  echo \"check: below threshold, skipping maintenance\"\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"for ep in \"${MEMBERS[@]}\"; do\n" +
+		"  echo \"defrag ${ep}\"\n" +
+		"  etcdctl --endpoints=\"${ep}\" endpoint defrag\n" +
+		"  echo \"disarm alarms on ${ep}\"\n" +
+		"  etcdctl --endpoints=\"${ep}\" alarm disarm\n" +
+		"  sleep 2\n" +
+		"done\n"
+}
+
+func managedEtcdMemberClientEndpoints(cluster *kafscalev1alpha1.KafscaleCluster) []string {
+	peerSvc := fmt.Sprintf("%s-etcd", cluster.Name)
+	replicas := int(etcdReplicas())
+	if replicas < 1 {
+		replicas = 1
+	}
+	endpoints := make([]string, 0, replicas)
+	for i := 0; i < replicas; i++ {
+		endpoints = append(endpoints, fmt.Sprintf(
+			"http://%s-etcd-%d.%s.%s.svc.cluster.local:2379",
+			cluster.Name, i, peerSvc, cluster.Namespace,
+		))
+	}
+	return endpoints
+}
+
 func snapshotBucket(cluster *kafscalev1alpha1.KafscaleCluster) string {
 	bucket := strings.TrimSpace(os.Getenv(operatorEtcdSnapshotBucketEnv))
 	if bucket == "" {
@@ -721,4 +927,66 @@ func stringPtrOrNil(val string) *string {
 		return nil
 	}
 	return &val
+}
+
+// etcdQuotaBackendBytes returns the configured backend quota in bytes, or the
+// default. Empty or non-positive / unparseable values fall back to the default
+// so a garbage override never disables the quota.
+func etcdQuotaBackendBytes() int64 {
+	raw := strings.TrimSpace(os.Getenv(operatorEtcdQuotaBackendBytesEnv))
+	if raw == "" {
+		return defaultEtcdQuotaBackendBytes
+	}
+	parsed, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || parsed <= 0 {
+		return defaultEtcdQuotaBackendBytes
+	}
+	return parsed
+}
+
+// etcdAutoCompactionRetention returns the configured retention window, or the
+// default. The value is passed verbatim to etcd, which interprets it per the
+// compaction mode (a duration like "5m" for periodic, a count for revision).
+func etcdAutoCompactionRetention() string {
+	raw := strings.TrimSpace(os.Getenv(operatorEtcdAutoCompactionRetentionEnv))
+	if raw == "" {
+		return defaultEtcdAutoCompactionRetention
+	}
+	return raw
+}
+
+// etcdAutoCompactionMode returns the configured compaction mode, restricted to
+// the two values etcd accepts ("periodic", "revision"); anything else falls
+// back to the default.
+func etcdAutoCompactionMode() string {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(operatorEtcdAutoCompactionModeEnv))) {
+	case "periodic":
+		return "periodic"
+	case "revision":
+		return "revision"
+	default:
+		return defaultEtcdAutoCompactionMode
+	}
+}
+
+func etcdMaintenanceSchedule() string {
+	if raw := strings.TrimSpace(os.Getenv(operatorEtcdMaintenanceScheduleEnv)); raw != "" {
+		return raw
+	}
+	return getEnv(operatorEtcdDefragScheduleEnv, defaultEtcdMaintenanceSchedule)
+}
+
+func etcdMaintenanceCheckSchedule() string {
+	return getEnv(operatorEtcdMaintenanceCheckScheduleEnv, defaultEtcdMaintenanceCheckSchedule)
+}
+
+// etcdMaintenanceEnabled returns true unless explicitly disabled.
+func etcdMaintenanceEnabled() bool {
+	for _, key := range []string{operatorEtcdMaintenanceEnabledEnv, operatorEtcdDefragEnabledEnv} {
+		switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
+		case "0", "false", "no", "off":
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/operator/etcd_resources_test.go
+++ b/pkg/operator/etcd_resources_test.go
@@ -17,6 +17,7 @@ package operator
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -93,6 +94,8 @@ func TestEnsureEtcdCreatesManagedCluster(t *testing.T) {
 	assertFound(t, c, &corev1.Service{}, cluster.Namespace, cluster.Name+"-etcd-client")
 	assertFound(t, c, &policyv1.PodDisruptionBudget{}, cluster.Namespace, cluster.Name+"-etcd")
 	assertFound(t, c, &batchv1.CronJob{}, cluster.Namespace, cluster.Name+"-etcd-snapshot")
+	assertFound(t, c, &batchv1.CronJob{}, cluster.Namespace, cluster.Name+"-etcd-maintenance")
+	assertFound(t, c, &batchv1.CronJob{}, cluster.Namespace, cluster.Name+"-etcd-maintenance-check")
 
 	sts := &appsv1.StatefulSet{}
 	assertFound(t, c, sts, cluster.Namespace, cluster.Name+"-etcd")
@@ -185,6 +188,202 @@ func TestSnapshotStaleAfterEnv(t *testing.T) {
 	t.Setenv(operatorEtcdSnapshotStaleAfterEnv, "0")
 	if got := snapshotStaleAfterSeconds(); got != defaultSnapshotStaleAfterSeconds {
 		t.Fatalf("expected default stale after, got %d", got)
+	}
+}
+
+// argValue returns the value of a `--flag=value` argument, or "" if the flag
+// is not present in args.
+func argValue(args []string, flag string) string {
+	prefix := flag + "="
+	for _, a := range args {
+		if strings.HasPrefix(a, prefix) {
+			return strings.TrimPrefix(a, prefix)
+		}
+	}
+	return ""
+}
+
+func TestEtcdArgsSpaceManagement(t *testing.T) {
+	cluster := testCluster("compaction", nil)
+
+	cases := []struct {
+		name          string
+		env           map[string]string
+		wantMode      string
+		wantRetention string
+		wantQuota     string
+	}{
+		{
+			name:          "defaults",
+			env:           nil,
+			wantMode:      "periodic",
+			wantRetention: "5m",
+			wantQuota:     "4294967296", // 4 GiB
+		},
+		{
+			name: "env overrides",
+			env: map[string]string{
+				operatorEtcdAutoCompactionModeEnv:      "revision",
+				operatorEtcdAutoCompactionRetentionEnv: "10000",
+				operatorEtcdQuotaBackendBytesEnv:       "8589934592", // 8 GiB
+			},
+			wantMode:      "revision",
+			wantRetention: "10000",
+			wantQuota:     "8589934592",
+		},
+		{
+			name: "garbage falls back to defaults",
+			env: map[string]string{
+				operatorEtcdAutoCompactionModeEnv:      "bogus",
+				operatorEtcdAutoCompactionRetentionEnv: "", // empty -> default
+				operatorEtcdQuotaBackendBytesEnv:       "-1",
+			},
+			wantMode:      "periodic",
+			wantRetention: "5m",
+			wantQuota:     "4294967296",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+			args := etcdArgs(cluster)
+			if got := argValue(args, "--auto-compaction-mode"); got != tc.wantMode {
+				t.Errorf("auto-compaction-mode = %q, want %q", got, tc.wantMode)
+			}
+			if got := argValue(args, "--auto-compaction-retention"); got != tc.wantRetention {
+				t.Errorf("auto-compaction-retention = %q, want %q", got, tc.wantRetention)
+			}
+			if got := argValue(args, "--quota-backend-bytes"); got != tc.wantQuota {
+				t.Errorf("quota-backend-bytes = %q, want %q", got, tc.wantQuota)
+			}
+		})
+	}
+}
+
+func TestEtcdMemoryModeSetsContainerMemoryLimit(t *testing.T) {
+	t.Setenv(operatorEtcdEndpointsEnv, "")
+	t.Setenv(operatorEtcdStorageMemoryEnv, "true")
+	cluster := testCluster("mem-guard", nil)
+	scheme := testScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).Build()
+
+	if _, err := EnsureEtcd(context.Background(), c, scheme, cluster); err != nil {
+		t.Fatalf("EnsureEtcd: %v", err)
+	}
+
+	sts := &appsv1.StatefulSet{}
+	assertFound(t, c, sts, cluster.Namespace, cluster.Name+"-etcd")
+	if len(sts.Spec.VolumeClaimTemplates) != 0 {
+		t.Fatalf("memory mode should not declare a PVC template, got %d", len(sts.Spec.VolumeClaimTemplates))
+	}
+	if len(sts.Spec.Template.Spec.Containers) == 0 {
+		t.Fatalf("expected etcd container")
+	}
+	res := sts.Spec.Template.Spec.Containers[0].Resources
+	memReq, okReq := res.Requests[corev1.ResourceMemory]
+	memLim, okLim := res.Limits[corev1.ResourceMemory]
+	if !okReq || !okLim {
+		t.Fatalf("memory mode must set memory request and limit, got requests=%v limits=%v", res.Requests, res.Limits)
+	}
+	// request == quota (4 GiB), limit == quota + 512 MiB headroom.
+	if got := memReq.Value(); got != defaultEtcdQuotaBackendBytes {
+		t.Errorf("memory request = %d, want %d", got, defaultEtcdQuotaBackendBytes)
+	}
+	if got := memLim.Value(); got != defaultEtcdQuotaBackendBytes+(512*1024*1024) {
+		t.Errorf("memory limit = %d, want %d", got, defaultEtcdQuotaBackendBytes+(512*1024*1024))
+	}
+}
+
+func TestEtcdMaintenanceCronJobs(t *testing.T) {
+	t.Setenv(operatorEtcdEndpointsEnv, "")
+	t.Setenv(operatorEtcdMaintenanceScheduleEnv, "15 4 * * *")
+	t.Setenv(operatorEtcdMaintenanceCheckScheduleEnv, "*/10 * * * *")
+	cluster := testCluster("maintenance", nil)
+	scheme := testScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).Build()
+
+	if _, err := EnsureEtcd(context.Background(), c, scheme, cluster); err != nil {
+		t.Fatalf("EnsureEtcd: %v", err)
+	}
+
+	cron := &batchv1.CronJob{}
+	assertFound(t, c, cron, cluster.Namespace, cluster.Name+"-etcd-maintenance")
+	if cron.Spec.Schedule != "15 4 * * *" {
+		t.Fatalf("maintenance schedule = %q, want %q", cron.Spec.Schedule, "15 4 * * *")
+	}
+	if got := cron.Labels["kafscale.io/etcd-task"]; got != "maintenance" {
+		t.Fatalf("maintenance task label = %q, want maintenance", got)
+	}
+	maintenance := cron.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
+	if got := envValue(maintenance.Env, "CHECK_ONLY"); got != "0" {
+		t.Fatalf("CHECK_ONLY = %q, want 0", got)
+	}
+	script := strings.Join(maintenance.Args, "\n")
+	if !strings.Contains(script, "endpoint defrag") || !strings.Contains(script, "alarm disarm") {
+		t.Fatalf("maintenance script missing defrag/disarm: %s", script)
+	}
+
+	check := &batchv1.CronJob{}
+	assertFound(t, c, check, cluster.Namespace, cluster.Name+"-etcd-maintenance-check")
+	if check.Spec.Schedule != "*/10 * * * *" {
+		t.Fatalf("check schedule = %q, want %q", check.Spec.Schedule, "*/10 * * * *")
+	}
+	if got := envValue(check.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env, "CHECK_ONLY"); got != "1" {
+		t.Fatalf("checker CHECK_ONLY = %q, want 1", got)
+	}
+}
+
+func TestEtcdMaintenanceDisabled(t *testing.T) {
+	t.Setenv(operatorEtcdEndpointsEnv, "")
+	t.Setenv(operatorEtcdMaintenanceEnabledEnv, "0")
+	cluster := testCluster("maintenance-off", nil)
+	scheme := testScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).Build()
+
+	if _, err := EnsureEtcd(context.Background(), c, scheme, cluster); err != nil {
+		t.Fatalf("EnsureEtcd: %v", err)
+	}
+
+	assertNotFound(t, c, &batchv1.CronJob{}, cluster.Namespace, cluster.Name+"-etcd-maintenance")
+	assertNotFound(t, c, &batchv1.CronJob{}, cluster.Namespace, cluster.Name+"-etcd-maintenance-check")
+}
+
+func TestEtcdMaintenanceSizeThresholdPct(t *testing.T) {
+	t.Setenv(operatorEtcdMaintenanceSizeThresholdPctEnv, "80")
+	if got := etcdMaintenanceSizeThresholdPct(); got != 80 {
+		t.Fatalf("threshold pct = %d, want 80", got)
+	}
+	if got := etcdMaintenanceSizeThresholdBytes(1000); got != 800 {
+		t.Fatalf("threshold bytes = %d, want 800", got)
+	}
+	t.Setenv(operatorEtcdMaintenanceSizeThresholdPctEnv, "0")
+	if got := etcdMaintenanceSizeThresholdPct(); got != defaultEtcdMaintenanceSizeThresholdPct {
+		t.Fatalf("expected default threshold pct, got %d", got)
+	}
+}
+
+func TestEtcdDiskModeHasNoContainerMemoryLimit(t *testing.T) {
+	t.Setenv(operatorEtcdEndpointsEnv, "")
+	// storage-memory mode explicitly off (the default); disk-backed PVC path.
+	cluster := testCluster("disk-mode", nil)
+	scheme := testScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).Build()
+
+	if _, err := EnsureEtcd(context.Background(), c, scheme, cluster); err != nil {
+		t.Fatalf("EnsureEtcd: %v", err)
+	}
+
+	sts := &appsv1.StatefulSet{}
+	assertFound(t, c, sts, cluster.Namespace, cluster.Name+"-etcd")
+	if len(sts.Spec.VolumeClaimTemplates) == 0 {
+		t.Fatalf("disk mode must declare a PVC template")
+	}
+	res := sts.Spec.Template.Spec.Containers[0].Resources
+	if len(res.Requests) != 0 || len(res.Limits) != 0 {
+		t.Fatalf("disk mode must not set container resources, got requests=%v limits=%v", res.Requests, res.Limits)
 	}
 }
 

--- a/pkg/operator/metrics.go
+++ b/pkg/operator/metrics.go
@@ -58,6 +58,22 @@ var (
 		Name: "kafscale_operator_etcd_snapshot_access_ok",
 		Help: "1 if the operator can write to the snapshot bucket.",
 	}, []string{"cluster"})
+	operatorEtcdDbTotalSizeBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "kafscale_operator_etcd_db_total_size_bytes",
+		Help: "Physical etcd backend size per managed member.",
+	}, []string{"cluster", "member"})
+	operatorEtcdDbInUseBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "kafscale_operator_etcd_db_in_use_bytes",
+		Help: "Logical in-use etcd backend size per managed member.",
+	}, []string{"cluster", "member"})
+	operatorEtcdDbSizeHigh = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "kafscale_operator_etcd_db_size_high",
+		Help: "1 when any managed etcd member exceeds the maintenance size threshold.",
+	}, []string{"cluster"})
+	operatorEtcdNospaceAlarm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "kafscale_operator_etcd_nospace_alarm",
+		Help: "1 when the managed etcd cluster has an active NOSPACE alarm.",
+	}, []string{"cluster"})
 )
 
 func init() {
@@ -70,6 +86,10 @@ func init() {
 		operatorEtcdSnapshotStale,
 		operatorEtcdSnapshotSuccess,
 		operatorEtcdSnapshotAccessOK,
+		operatorEtcdDbTotalSizeBytes,
+		operatorEtcdDbInUseBytes,
+		operatorEtcdDbSizeHigh,
+		operatorEtcdNospaceAlarm,
 	)
 }
 

--- a/scripts/etcd-load-test.sh
+++ b/scripts/etcd-load-test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright 2026 KafScale team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+TOPIC="${TOPIC:-etcd-load}"
+NUM_RECORDS="${NUM_RECORDS:-5000000}"
+RECORD_SIZE="${RECORD_SIZE:-256}"
+THROUGHPUT="${THROUGHPUT:-5000}"
+BOOTSTRAP="${BOOTSTRAP:-localhost:9092}"
+NAMESPACE="${NAMESPACE:-kafscale}"
+CLUSTER="${CLUSTER:-kafscale}"
+
+echo "==> producer load: topic=${TOPIC} records=${NUM_RECORDS} throughput=${THROUGHPUT}"
+kafka-producer-perf-test \
+  --topic "${TOPIC}" \
+  --num-records "${NUM_RECORDS}" \
+  --record-size "${RECORD_SIZE}" \
+  --throughput "${THROUGHPUT}" \
+  --producer-props "bootstrap.servers=${BOOTSTRAP}"
+
+echo "==> etcd endpoint status"
+kubectl -n "${NAMESPACE}" exec "${CLUSTER}-etcd-0" -- \
+  etcdctl --endpoints="http://127.0.0.1:2379" endpoint status --write-out=table
+
+echo "==> maintenance cronjobs"
+kubectl -n "${NAMESPACE}" get cronjob | rg 'etcd-maintenance|NAME'
+
+echo "==> recent maintenance jobs"
+kubectl -n "${NAMESPACE}" get jobs | rg 'etcd-maintenance' || true

--- a/scripts/etcd-load-test.sh
+++ b/scripts/etcd-load-test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Copyright 2026 KafScale team.
+# Copyright 2026 Alexander Alten (novatechflow), NovaTechflow (novatechflow.com).
+# This project is supported and financed by Scalytics, Inc. (www.scalytics.io).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/etcd-load-test.sh
+++ b/scripts/etcd-load-test.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2026 Alexander Alten (novatechflow), NovaTechflow (novatechflow.com).
-# This project is supported and financed by Scalytics, Inc. (www.scalytics.io).
+# Copyright 2026 KafScale team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Managed etcd hits `mvcc: database space exceeded` under sustained produce load.

- etcd flags: periodic compaction (5m) + 4 GiB quota
- `{cluster}-etcd-maintenance` CronJob (6h): defrag + NOSPACE disarm per member
- `{cluster}-etcd-maintenance-check` CronJob (15m): reactive maintenance when size > 75% quota or NOSPACE alarm
- Operator metrics: `kafscale_operator_etcd_db_*`, `kafscale_operator_etcd_nospace_alarm`
- PrometheusRule: `KafscaleEtcdBackendSizeHigh`, `KafscaleEtcdNOSPACE`
- Load test: `scripts/etcd-load-test.sh`

Docs: `docs/operations.md`, `docs/metrics.md`