### PR TITLE
feat(chart): PodSecurity 'restricted'-compatible securityContext on workloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,3 +95,8 @@ jobs:
 
       - name: Lint chart
         run: helm lint deploy/helm/kafscale
+
+      - name: Chart conformance tests
+        run: |
+          make test-chart-proxy-nodeport
+          make test-chart-psa

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ LOCAL_NODE_BIN := $(LOCAL_NODE_DIR)/bin
 LOCAL_NODE := $(LOCAL_NODE_BIN)/node
 LOCAL_NPM := $(LOCAL_NODE_BIN)/npm
 
-.PHONY: proto build test test-nested-modules tidy lint generate build-sdk docker-build docker-build-e2e-client docker-build-etcd-tools docker-clean ensure-minio start-minio stop-containers release-broker-ports test-produce-consume test-produce-consume-debug test-consumer-group test-ops-api test-mcp test-multi-segment-durability test-full test-operator test-acl demo demo-platform demo-platform-bootstrap iceberg-demo kafsql-demo platform-demo help clean-kind-all ensure-local-node check vet race fmt fmt-check test-fuzz code-ql code-ql-summary code-ql-gate commit-check test-chart-proxy-nodeport
+.PHONY: proto build test test-nested-modules tidy lint generate build-sdk docker-build docker-build-e2e-client docker-build-etcd-tools docker-clean ensure-minio start-minio stop-containers release-broker-ports test-produce-consume test-produce-consume-debug test-consumer-group test-ops-api test-mcp test-multi-segment-durability test-full test-operator test-acl demo demo-platform demo-platform-bootstrap iceberg-demo kafsql-demo platform-demo help clean-kind-all ensure-local-node check vet race fmt fmt-check test-fuzz code-ql code-ql-summary code-ql-gate commit-check test-chart-proxy-nodeport test-chart-psa
 
 REGISTRY ?= ghcr.io/kafscale
 STAMP_DIR ?= .build
@@ -207,6 +207,9 @@ test-fuzz: ## Run Go fuzz test(s)
 
 test-chart-proxy-nodeport: ## Run the proxy Service nodePort chart template test (helm only, no cluster)
 	bash test/chart/proxy-nodeport_test.sh
+
+test-chart-psa: ## Run the PodSecurity restricted conformance chart test (helm only, no cluster)
+	bash test/chart/psa-restricted_test.sh
 
 code-ql: ensure-local-node ## Run local CodeQL and emit SARIF under .tmp/codeql/
 	bash scripts/codeql_local.sh

--- a/deploy/helm/kafscale/Chart.yaml
+++ b/deploy/helm/kafscale/Chart.yaml
@@ -19,5 +19,5 @@ description: Helm chart for the Kafscale operator and console
 home: https://github.com/KafScale/platform
 icon: https://raw.githubusercontent.com/KafScale/platform/main/docs/assets/icon.png
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: "v1.5.0"

--- a/deploy/helm/kafscale/Chart.yaml
+++ b/deploy/helm/kafscale/Chart.yaml
@@ -19,5 +19,5 @@ description: Helm chart for the Kafscale operator and console
 home: https://github.com/KafScale/platform
 icon: https://raw.githubusercontent.com/KafScale/platform/main/docs/assets/icon.png
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: "v1.5.0"

--- a/deploy/helm/kafscale/templates/console-deployment.yaml
+++ b/deploy/helm/kafscale/templates/console-deployment.yaml
@@ -41,10 +41,18 @@ spec:
         - name: {{ . }}
 {{- end }}
 {{- end }}
+{{- with .Values.console.podSecurityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+{{- end }}
       containers:
         - name: console
           image: "{{ .Values.console.image.repository }}:{{ ternary "latest" (default .Chart.AppVersion .Values.console.image.tag) .Values.console.image.useLatest }}"
           imagePullPolicy: {{ ternary "Always" .Values.console.image.pullPolicy .Values.console.image.useLatest }}
+{{- with .Values.console.containerSecurityContext }}
+          securityContext:
+{{ toYaml . | indent 12 }}
+{{- end }}
           env:
             - name: KAFSCALE_CONSOLE_HTTP_ADDR
               value: ":8080"

--- a/deploy/helm/kafscale/templates/mcp-deployment.yaml
+++ b/deploy/helm/kafscale/templates/mcp-deployment.yaml
@@ -43,10 +43,18 @@ spec:
 {{- end }}
 {{- end }}
       serviceAccountName: {{ include "kafscale.mcpServiceAccountName" . }}
+{{- with .Values.mcp.podSecurityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+{{- end }}
       containers:
         - name: mcp
           image: "{{ .Values.mcp.image.repository }}:{{ ternary "latest" (default .Chart.AppVersion .Values.mcp.image.tag) .Values.mcp.image.useLatest }}"
           imagePullPolicy: {{ ternary "Always" .Values.mcp.image.pullPolicy .Values.mcp.image.useLatest }}
+{{- with .Values.mcp.containerSecurityContext }}
+          securityContext:
+{{ toYaml . | indent 12 }}
+{{- end }}
           env:
             - name: KAFSCALE_MCP_HTTP_ADDR
               value: ":8090"

--- a/deploy/helm/kafscale/templates/operator-deployment.yaml
+++ b/deploy/helm/kafscale/templates/operator-deployment.yaml
@@ -41,10 +41,18 @@ spec:
         - name: {{ . }}
 {{- end }}
 {{- end }}
+{{- with .Values.operator.podSecurityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+{{- end }}
       containers:
         - name: operator
           image: "{{ .Values.operator.image.repository }}:{{ ternary "latest" (default .Chart.AppVersion .Values.operator.image.tag) .Values.operator.image.useLatest }}"
           imagePullPolicy: {{ ternary "Always" .Values.operator.image.pullPolicy .Values.operator.image.useLatest }}
+{{- with .Values.operator.containerSecurityContext }}
+          securityContext:
+{{ toYaml . | indent 12 }}
+{{- end }}
           ports:
             - name: metrics
               containerPort: {{ .Values.operator.metrics.port }}

--- a/deploy/helm/kafscale/templates/proxy-deployment.yaml
+++ b/deploy/helm/kafscale/templates/proxy-deployment.yaml
@@ -115,6 +115,16 @@ spec:
 {{- else }}
             {}
 {{- end }}
+          # The proxy LFS verify path writes a temp file via os.CreateTemp("", ...)
+          # which resolves to /tmp. With readOnlyRootFilesystem: true the root FS is
+          # read-only, so /tmp must be a writable mount or LFS verify returns HTTP 500.
+          # This emptyDir keeps the restricted default and LFS coexisting.
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
 {{- with .Values.proxy.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/deploy/helm/kafscale/templates/proxy-deployment.yaml
+++ b/deploy/helm/kafscale/templates/proxy-deployment.yaml
@@ -41,10 +41,18 @@ spec:
         - name: {{ . }}
 {{- end }}
 {{- end }}
+{{- with .Values.proxy.podSecurityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+{{- end }}
       containers:
         - name: proxy
           image: "{{ .Values.proxy.image.repository }}:{{ ternary "latest" (default .Chart.AppVersion .Values.proxy.image.tag) .Values.proxy.image.useLatest }}"
           imagePullPolicy: {{ ternary "Always" .Values.proxy.image.pullPolicy .Values.proxy.image.useLatest }}
+{{- with .Values.proxy.containerSecurityContext }}
+          securityContext:
+{{ toYaml . | indent 12 }}
+{{- end }}
           env:
             - name: KAFSCALE_PROXY_ADDR
               value: ":{{ .Values.proxy.service.port }}"

--- a/deploy/helm/kafscale/values.yaml
+++ b/deploy/helm/kafscale/values.yaml
@@ -57,16 +57,18 @@ operator:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  # Pod-level security context. PSA-restricted compliant defaults: the
-  # operator image runs as USER 10001 (Dockerfile-baked), so we declare
-  # runAsNonRoot + fsGroup at the pod level. Override per-environment
-  # via `--set operator.podSecurityContext.<key>=<value>` or an
-  # environment values file.
+  # Pod-level security context. PSA-restricted compliant defaults.
+  # These defaults assume the shipped images (UID 10001). If you override
+  # image.repository with a root-running image, set
+  # operator.podSecurityContext.runAsNonRoot=false. Override per-environment
+  # via `--set operator.podSecurityContext.<key>=<value>` or a values file.
   podSecurityContext:
     runAsNonRoot: true
+    # runAsUser/runAsGroup pin the Dockerfile-baked USER 10001. If the image
+    # USER changes, change this in lockstep. PSA restricted itself only
+    # requires runAsNonRoot, not a specific UID.
     runAsUser: 10001
     runAsGroup: 10001
-    fsGroup: 10001
     seccompProfile:
       type: RuntimeDefault
   # Container-level security context. PSA-restricted-required defaults.
@@ -126,13 +128,15 @@ console:
   tolerations: []
   affinity: {}
   # PSA-restricted compliant defaults. The console image runs as
-  # USER 10001 (Dockerfile-baked); pod + container security context
-  # declare the four PSA-restricted requirements.
+  # USER 10001 (Dockerfile-baked). These defaults assume the shipped image;
+  # if you override image.repository with a root-running image, set
+  # console.podSecurityContext.runAsNonRoot=false.
   podSecurityContext:
     runAsNonRoot: true
+    # runAsUser/runAsGroup pin the Dockerfile-baked USER 10001. Change in
+    # lockstep with the image USER. PSA restricted requires only runAsNonRoot.
     runAsUser: 10001
     runAsGroup: 10001
-    fsGroup: 10001
     seccompProfile:
       type: RuntimeDefault
   containerSecurityContext:
@@ -180,10 +184,16 @@ proxy:
   tolerations: []
   affinity: {}
   # PSA-restricted compliant defaults. The proxy image runs as
-  # USER 10001 (Dockerfile-baked); pod + container security context
-  # declare the four PSA-restricted requirements.
+  # USER 10001 (Dockerfile-baked). These defaults assume the shipped image;
+  # if you override image.repository with a root-running image, set
+  # proxy.podSecurityContext.runAsNonRoot=false.
+  # fsGroup is kept here (unlike operator/console) because the proxy mounts a
+  # writable /tmp emptyDir for the LFS verify path; fsGroup sets that volume's
+  # group ownership so the non-root process can write to it.
   podSecurityContext:
     runAsNonRoot: true
+    # runAsUser/runAsGroup pin the Dockerfile-baked USER 10001. Change in
+    # lockstep with the image USER. PSA restricted requires only runAsNonRoot.
     runAsUser: 10001
     runAsGroup: 10001
     fsGroup: 10001
@@ -267,6 +277,23 @@ mcp:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # PSA-restricted compliant defaults. The mcp image runs as
+  # USER 10001 (Dockerfile-baked, deploy/docker/mcp.Dockerfile). These
+  # defaults assume the shipped image; if you override image.repository with
+  # a root-running image, set mcp.podSecurityContext.runAsNonRoot=false.
+  podSecurityContext:
+    runAsNonRoot: true
+    # runAsUser/runAsGroup pin the Dockerfile-baked USER 10001. Change in
+    # lockstep with the image USER. PSA restricted requires only runAsNonRoot.
+    runAsUser: 10001
+    runAsGroup: 10001
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: ["ALL"]
   service:
     type: ClusterIP
     port: 80

--- a/deploy/helm/kafscale/values.yaml
+++ b/deploy/helm/kafscale/values.yaml
@@ -57,6 +57,24 @@ operator:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # Pod-level security context. PSA-restricted compliant defaults: the
+  # operator image runs as USER 10001 (Dockerfile-baked), so we declare
+  # runAsNonRoot + fsGroup at the pod level. Override per-environment
+  # via `--set operator.podSecurityContext.<key>=<value>` or an
+  # environment values file.
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 10001
+    runAsGroup: 10001
+    fsGroup: 10001
+    seccompProfile:
+      type: RuntimeDefault
+  # Container-level security context. PSA-restricted-required defaults.
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: ["ALL"]
   metrics:
     enabled: true
     port: 8080
@@ -107,6 +125,21 @@ console:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # PSA-restricted compliant defaults. The console image runs as
+  # USER 10001 (Dockerfile-baked); pod + container security context
+  # declare the four PSA-restricted requirements.
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 10001
+    runAsGroup: 10001
+    fsGroup: 10001
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: ["ALL"]
   service:
     type: ClusterIP
     port: 80
@@ -146,6 +179,21 @@ proxy:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # PSA-restricted compliant defaults. The proxy image runs as
+  # USER 10001 (Dockerfile-baked); pod + container security context
+  # declare the four PSA-restricted requirements.
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 10001
+    runAsGroup: 10001
+    fsGroup: 10001
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: ["ALL"]
   service:
     type: LoadBalancer
     port: 9092

--- a/test/chart/psa-restricted_test.sh
+++ b/test/chart/psa-restricted_test.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Copyright 2026 KafScale team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Chart conformance gate for the PodSecurity "restricted" profile.
+#
+# Asserts that every chart-templated Deployment (operator, proxy, console,
+# mcp) renders the five restricted controls:
+#   1. pod-level    runAsNonRoot: true
+#   2. container    allowPrivilegeEscalation: false
+#   3. container    capabilities.drop includes ALL
+#   4. pod-level    seccompProfile.type: RuntimeDefault
+#   5. pod-level    runAsUser: <non-zero>  (a non-root UID)
+#   6. container    readOnlyRootFilesystem: true
+#
+# Proxy additionally mounts a writable emptyDir at /tmp so the LFS verify path
+# (cmd/proxy/lfs_http.go, os.CreateTemp) works with a read-only root FS.
+#
+# This is the gate that catches a future Deployment being added without the
+# securityContext blocks (e.g. the mcp gap this test was written to close).
+# Self-contained: needs only helm and awk, no helm plugins, no cluster.
+# Run directly or via `make test-chart-psa`.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHART_DIR="${ROOT_DIR}/deploy/helm/kafscale"
+
+command -v helm >/dev/null 2>&1 || { echo "helm is required"; exit 1; }
+
+fail=0
+
+# Render a single Deployment template with every workload enabled. The proxy
+# and mcp are opt-in (enabled: false by default), so we enable all four here.
+render_deployment() {
+  local template="$1"
+  helm template kafscale "${CHART_DIR}" \
+    --show-only "templates/${template}" \
+    --set proxy.enabled=true \
+    --set console.enabled=true \
+    --set mcp.enabled=true
+}
+
+# assert_present <component> <description> <rendered-yaml> <grep-pattern>
+assert_present() {
+  local component="$1" desc="$2" yaml="$3" pattern="$4"
+  if printf '%s\n' "${yaml}" | grep -Eq "${pattern}"; then
+    echo "PASS: ${component}: ${desc}"
+  else
+    echo "FAIL: ${component}: ${desc} (pattern: ${pattern})"
+    fail=1
+  fi
+}
+
+# assert_runasuser_nonzero <component> <rendered-yaml>
+# runAsUser must be present and not 0 (0 is root, which violates restricted).
+assert_runasuser_nonzero() {
+  local component="$1" yaml="$2" uid
+  uid="$(printf '%s\n' "${yaml}" | awk '/^[[:space:]]*runAsUser:/ { print $2; exit }')"
+  if [ -n "${uid}" ] && [ "${uid}" != "0" ]; then
+    echo "PASS: ${component}: runAsUser is a non-root UID (runAsUser=${uid})"
+  else
+    echo "FAIL: ${component}: runAsUser must be a non-root UID (got \"${uid:-<absent>}\")"
+    fail=1
+  fi
+}
+
+echo "==> chart PSA-restricted conformance gate"
+
+# The chart-templated Deployments and their template files. Broker/etcd are
+# operator-reconciled (label app=kafscale-broker), not chart-templated, and
+# are intentionally out of scope for this chart-level gate.
+declare -a COMPONENTS=(
+  "operator:operator-deployment.yaml"
+  "proxy:proxy-deployment.yaml"
+  "console:console-deployment.yaml"
+  "mcp:mcp-deployment.yaml"
+)
+
+for entry in "${COMPONENTS[@]}"; do
+  component="${entry%%:*}"
+  template="${entry##*:}"
+  yaml="$(render_deployment "${template}")"
+
+  # 1. runAsNonRoot: true
+  assert_present "${component}" "runAsNonRoot: true" "${yaml}" \
+    '^[[:space:]]*runAsNonRoot:[[:space:]]*true[[:space:]]*$'
+  # 2. allowPrivilegeEscalation: false
+  assert_present "${component}" "allowPrivilegeEscalation: false" "${yaml}" \
+    '^[[:space:]]*allowPrivilegeEscalation:[[:space:]]*false[[:space:]]*$'
+  # 3. capabilities.drop includes ALL
+  assert_present "${component}" "capabilities.drop includes ALL" "${yaml}" \
+    '^[[:space:]]*-[[:space:]]*ALL[[:space:]]*$'
+  # 4. seccompProfile RuntimeDefault
+  assert_present "${component}" "seccompProfile.type: RuntimeDefault" "${yaml}" \
+    '^[[:space:]]*type:[[:space:]]*RuntimeDefault[[:space:]]*$'
+  # 5. non-root runAsUser
+  assert_runasuser_nonzero "${component}" "${yaml}"
+  # 6. readOnlyRootFilesystem: true
+  assert_present "${component}" "readOnlyRootFilesystem: true" "${yaml}" \
+    '^[[:space:]]*readOnlyRootFilesystem:[[:space:]]*true[[:space:]]*$'
+  if [ "${component}" = "proxy" ]; then
+    assert_present "${component}" "writable /tmp emptyDir mount" "${yaml}" \
+      'mountPath:[[:space:]]*/tmp'
+    assert_present "${component}" "tmp emptyDir volume" "${yaml}" \
+      '^[[:space:]]*- name:[[:space:]]*tmp[[:space:]]*$'
+  fi
+done
+
+if [ "${fail}" -ne 0 ]; then
+  echo "==> chart PSA-restricted conformance gate FAILED"
+  exit 1
+fi
+echo "==> chart PSA-restricted conformance gate passed (4 Deployments x 6 controls; proxy /tmp mount)"


### PR DESCRIPTION
## What

Add PodSecurity `restricted`-compatible `securityContext` blocks (pod + container) to every chart-templated Deployment, so the chart deploys into namespaces that enforce the Pod Security Admission `restricted` profile without per-workload patching. Each Deployment carries:

- pod level: `runAsNonRoot: true`, `runAsUser`/`runAsGroup: 10001`, `seccompProfile: RuntimeDefault`
- container level: `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `capabilities.drop: [ALL]`

All values are overridable via `values.yaml` or `--set <component>.podSecurityContext.<key>=<value>`.

## Why

Lets the chart deploy into `restricted` PSA namespaces with zero admission warnings and no per-workload patching.

## Coverage: all four Deployments

The chart templates four Deployments (operator, proxy, console, mcp). All four are now hardened. The `mcp` Deployment was previously missing the blocks; this revision adds them (`templates/mcp-deployment.yaml`, wired to `.Values.mcp.podSecurityContext` / `.Values.mcp.containerSecurityContext`). The mcp image bakes `USER 10001` (`deploy/docker/mcp.Dockerfile`), so the restricted defaults match the shipped image.

## LFS coexistence: writable /tmp on the proxy

With `readOnlyRootFilesystem: true` the root filesystem is read-only. The proxy LFS verify path (`cmd/proxy/lfs_http.go`, `os.CreateTemp("", ...)`) writes a temp file to `/tmp`, so it returns HTTP 500 (`temp_storage_failed`) when `KAFSCALE_PROXY_LFS_ENABLED=true`. The proxy Deployment now mounts a writable `emptyDir` at `/tmp`, so the restricted default and LFS coexist. `readOnlyRootFilesystem` stays `true`. The proxy keeps `fsGroup` (it owns the volume); operator, console, and mcp drop `fsGroup` since they mount no volumes.

## Test: conformance gate

`test/chart/psa-restricted_test.sh`, wired as `make test-chart-psa`, follows the existing `test/chart` pattern (helm only, no plugins, no cluster). It renders every chart Deployment with all workloads enabled and asserts the five restricted controls on each (operator, proxy, console, mcp x runAsNonRoot true, allowPrivilegeEscalation false, capabilities.drop includes ALL, seccompProfile RuntimeDefault, non-root runAsUser). This gate fails automatically if a future Deployment is added without the blocks. Verified: removing the mcp blocks makes the gate fail; restoring makes it pass. `helm lint` and `helm template` of all four Deployments are clean.

## UID pin and overrides

`runAsUser`/`runAsGroup: 10001` pin the Dockerfile-baked `USER 10001` of the shipped images and must change in lockstep with that image USER; a values comment records this. PSA `restricted` itself only requires `runAsNonRoot`, not a specific UID. If you override `image.repository` with a root-running image, set `<component>.podSecurityContext.runAsNonRoot=false`.

## Scope

The brokers and etcd are operator-reconciled (label `app=kafscale-broker`), not chart-templated, so they are intentionally out of scope for this chart-level change and tracked separately. Default render is unchanged in shape; the hardening defaults are safe for the shipped images and fully overridable.

Part of a small series upstreaming deployment-hardening deltas we currently carry. Chart `0.4.1` -> `0.4.2`.
