### PR TITLE
feat: soft pod anti-affinity for broker, etcd, and proxy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,4 @@ jobs:
         run: |
           make test-chart-proxy-nodeport
           make test-chart-psa
+          make test-chart-antiaffinity

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ LOCAL_NODE_BIN := $(LOCAL_NODE_DIR)/bin
 LOCAL_NODE := $(LOCAL_NODE_BIN)/node
 LOCAL_NPM := $(LOCAL_NODE_BIN)/npm
 
-.PHONY: proto build test test-nested-modules tidy lint generate build-sdk docker-build docker-build-e2e-client docker-build-etcd-tools docker-clean ensure-minio start-minio stop-containers release-broker-ports test-produce-consume test-produce-consume-debug test-consumer-group test-ops-api test-mcp test-multi-segment-durability test-full test-operator test-acl demo demo-platform demo-platform-bootstrap iceberg-demo kafsql-demo platform-demo help clean-kind-all ensure-local-node check vet race fmt fmt-check test-fuzz code-ql code-ql-summary code-ql-gate commit-check test-chart-proxy-nodeport test-chart-psa
+.PHONY: proto build test test-nested-modules tidy lint generate build-sdk docker-build docker-build-e2e-client docker-build-etcd-tools docker-clean ensure-minio start-minio stop-containers release-broker-ports test-produce-consume test-produce-consume-debug test-consumer-group test-ops-api test-mcp test-multi-segment-durability test-full test-operator test-acl demo demo-platform demo-platform-bootstrap iceberg-demo kafsql-demo platform-demo help clean-kind-all ensure-local-node check vet race fmt fmt-check test-fuzz code-ql code-ql-summary code-ql-gate commit-check test-chart-proxy-nodeport test-chart-psa test-chart-antiaffinity
 
 REGISTRY ?= ghcr.io/kafscale
 STAMP_DIR ?= .build
@@ -210,6 +210,9 @@ test-chart-proxy-nodeport: ## Run the proxy Service nodePort chart template test
 
 test-chart-psa: ## Run the PodSecurity restricted conformance chart test (helm only, no cluster)
 	bash test/chart/psa-restricted_test.sh
+
+test-chart-antiaffinity: ## Run the proxy default podAntiAffinity chart template test (helm only, no cluster)
+	bash test/chart/proxy-antiaffinity_test.sh
 
 code-ql: ensure-local-node ## Run local CodeQL and emit SARIF under .tmp/codeql/
 	bash scripts/codeql_local.sh

--- a/deploy/helm/kafscale/Chart.yaml
+++ b/deploy/helm/kafscale/Chart.yaml
@@ -19,5 +19,5 @@ description: Helm chart for the Kafscale operator and console
 home: https://github.com/KafScale/platform
 icon: https://raw.githubusercontent.com/KafScale/platform/main/docs/assets/icon.png
 type: application
-version: 0.4.2
+version: 0.4.3
 appVersion: "v1.5.0"

--- a/deploy/helm/kafscale/templates/proxy-deployment.yaml
+++ b/deploy/helm/kafscale/templates/proxy-deployment.yaml
@@ -137,4 +137,8 @@ spec:
       affinity:
 {{ toYaml . | indent 8 }}
 {{- end }}
+{{- with .Values.proxy.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml . | indent 8 }}
+{{- end }}
 {{- end }}

--- a/deploy/helm/kafscale/templates/proxy-deployment.yaml
+++ b/deploy/helm/kafscale/templates/proxy-deployment.yaml
@@ -133,12 +133,24 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
 {{- end }}
-{{- with .Values.proxy.affinity }}
+{{- if .Values.proxy.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
-{{- end }}
-{{- with .Values.proxy.topologySpreadConstraints }}
-      topologySpreadConstraints:
-{{ toYaml . | indent 8 }}
+{{ toYaml .Values.proxy.affinity | indent 8 }}
+{{- else }}
+      # Default soft anti-affinity. The label selector is templated from the
+      # proxy's own pod labels (the same componentSelectorLabels helper used
+      # for the pod template above), so it always matches the pods it spreads,
+      # even when nameOverride/fullnameOverride changes the rendered name. Soft
+      # (preferredDuring) so single-node clusters still schedule every replica.
+      # Replaced by proxy.affinity when that value is set.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+{{ include "kafscale.componentSelectorLabels" (dict "root" . "component" "proxy") | indent 20 }}
+                topologyKey: kubernetes.io/hostname
 {{- end }}
 {{- end }}

--- a/deploy/helm/kafscale/values.yaml
+++ b/deploy/helm/kafscale/values.yaml
@@ -182,6 +182,19 @@ proxy:
   resources: {}
   nodeSelector: {}
   tolerations: []
+  # Pod affinity for the proxy Deployment.
+  #
+  # When left empty, proxy-deployment.yaml renders a default soft
+  # (preferredDuring) podAntiAffinity that prefers to place the proxy
+  # replicas on different nodes, with a label selector templated from the
+  # proxy's own pod labels so it always matches the pods it spreads, even
+  # under nameOverride/fullnameOverride. Soft so single-node KIND clusters
+  # still schedule every replica; flip to requiredDuring in multi-node
+  # production by setting an explicit affinity here.
+  #
+  # Backward-compat note: setting this key REPLACES the chart default
+  # rather than merging with it. If you want anti-affinity plus extra
+  # affinity rules, include the anti-affinity block in your override.
   affinity: {}
   # PSA-restricted compliant defaults. The proxy image runs as
   # USER 10001 (Dockerfile-baked). These defaults assume the shipped image;

--- a/pkg/operator/antiaffinity_test.go
+++ b/pkg/operator/antiaffinity_test.go
@@ -1,0 +1,98 @@
+// Copyright 2025 Alexander Alten (novatechflow), NovaTechflow (novatechflow.com).
+// This project is supported and financed by Scalytics, Inc. (www.scalytics.io).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// assertSpreadsOwnPods asserts that the StatefulSet carries a single soft
+// (preferred) podAntiAffinity term whose label selector EQUALS the pod-template
+// labels and whose topology key is the node hostname. That equality is the
+// property that makes the rule work: the selector matches the very pods the
+// term is meant to spread. A mismatch (the proxy selector-drift class of bug)
+// would leave the rule matching nothing and HA silently disabled.
+func assertSpreadsOwnPods(t *testing.T, sts *appsv1.StatefulSet) {
+	t.Helper()
+
+	aff := sts.Spec.Template.Spec.Affinity
+	if aff == nil || aff.PodAntiAffinity == nil {
+		t.Fatalf("expected podAntiAffinity on %s, got %+v", sts.Name, aff)
+	}
+	terms := aff.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	if len(terms) != 1 {
+		t.Fatalf("expected exactly one preferred term on %s, got %d", sts.Name, len(terms))
+	}
+	if aff.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+		t.Fatalf("expected soft-only anti-affinity on %s, found a required term", sts.Name)
+	}
+
+	term := terms[0].PodAffinityTerm
+	if term.LabelSelector == nil {
+		t.Fatalf("expected a label selector on %s", sts.Name)
+	}
+	if term.TopologyKey != "kubernetes.io/hostname" {
+		t.Fatalf("expected topologyKey kubernetes.io/hostname on %s, got %q", sts.Name, term.TopologyKey)
+	}
+
+	podLabels := sts.Spec.Template.Labels
+	if len(podLabels) == 0 {
+		t.Fatalf("expected pod-template labels on %s", sts.Name)
+	}
+	if !reflect.DeepEqual(term.LabelSelector.MatchLabels, podLabels) {
+		t.Fatalf("anti-affinity selector on %s does not match its own pod labels:\n selector=%v\n podLabels=%v",
+			sts.Name, term.LabelSelector.MatchLabels, podLabels)
+	}
+}
+
+func TestBrokerStatefulSetAntiAffinitySpreadsOwnPods(t *testing.T) {
+	cluster := testCluster("affinity-broker", nil)
+	scheme := testScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).Build()
+	r := &ClusterReconciler{Client: c, Scheme: scheme}
+
+	if err := r.reconcileBrokerDeployment(context.Background(), cluster, []string{"http://etcd:2379"}); err != nil {
+		t.Fatalf("reconcileBrokerDeployment: %v", err)
+	}
+
+	sts := &appsv1.StatefulSet{}
+	assertFound(t, c, sts, cluster.Namespace, cluster.Name+"-broker")
+	assertSpreadsOwnPods(t, sts)
+}
+
+func TestEtcdStatefulSetAntiAffinitySpreadsOwnPods(t *testing.T) {
+	t.Setenv(operatorEtcdEndpointsEnv, "")
+	cluster := testCluster("affinity-etcd", nil)
+	scheme := testScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).Build()
+
+	res, err := EnsureEtcd(context.Background(), c, scheme, cluster)
+	if err != nil {
+		t.Fatalf("EnsureEtcd: %v", err)
+	}
+	if !res.Managed {
+		t.Fatalf("expected managed etcd so a StatefulSet is created")
+	}
+
+	sts := &appsv1.StatefulSet{}
+	assertFound(t, c, sts, cluster.Namespace, cluster.Name+"-etcd")
+	assertSpreadsOwnPods(t, sts)
+}

--- a/pkg/operator/cluster_controller.go
+++ b/pkg/operator/cluster_controller.go
@@ -163,11 +163,11 @@ func (r *ClusterReconciler) reconcileBrokerDeployment(ctx context.Context, clust
 }
 
 // softPodAntiAffinity returns a preferred (soft) pod anti-affinity that spreads
-// replicas across nodes by hostname. BUG-0012: operator-managed broker and etcd
-// StatefulSets shipped with no anti-affinity, so all replicas could land on one
-// node and a single node loss took the whole quorum. Soft (not required) so the
-// default single-node KIND demo still schedules every replica instead of leaving
-// them Pending; on a multi-node cluster the scheduler spreads them.
+// replicas across nodes by hostname, so a single-node loss does not take the
+// whole quorum (broker or etcd) at once. The selector reuses the pod-template
+// label map, so it always matches the very pods it is meant to spread. Soft
+// (not required) so a single-node cluster still schedules every replica instead
+// of leaving them Pending; on a multi-node cluster the scheduler spreads them.
 func softPodAntiAffinity(labels map[string]string) *corev1.Affinity {
 	return &corev1.Affinity{
 		PodAntiAffinity: &corev1.PodAntiAffinity{

--- a/pkg/operator/cluster_controller.go
+++ b/pkg/operator/cluster_controller.go
@@ -153,12 +153,35 @@ func (r *ClusterReconciler) reconcileBrokerDeployment(ctx context.Context, clust
 		sts.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
 		sts.Spec.Replicas = &replicas
 		sts.Spec.Template.Labels = labels
+		sts.Spec.Template.Spec.Affinity = softPodAntiAffinity(labels)
 		sts.Spec.Template.Spec.Containers = []corev1.Container{
 			r.brokerContainer(cluster, endpoints),
 		}
 		return controllerutil.SetControllerReference(cluster, sts, r.Scheme)
 	})
 	return err
+}
+
+// softPodAntiAffinity returns a preferred (soft) pod anti-affinity that spreads
+// replicas across nodes by hostname. BUG-0012: operator-managed broker and etcd
+// StatefulSets shipped with no anti-affinity, so all replicas could land on one
+// node and a single node loss took the whole quorum. Soft (not required) so the
+// default single-node KIND demo still schedules every replica instead of leaving
+// them Pending; on a multi-node cluster the scheduler spreads them.
+func softPodAntiAffinity(labels map[string]string) *corev1.Affinity {
+	return &corev1.Affinity{
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+				{
+					Weight: 100,
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{MatchLabels: labels},
+						TopologyKey:   "kubernetes.io/hostname",
+					},
+				},
+			},
+		},
+	}
 }
 
 func (r *ClusterReconciler) deleteLegacyBrokerDeployment(ctx context.Context, cluster *kafscalev1alpha1.KafscaleCluster) error {

--- a/pkg/operator/etcd_resources.go
+++ b/pkg/operator/etcd_resources.go
@@ -215,6 +215,7 @@ func reconcileEtcdStatefulSet(ctx context.Context, c client.Client, scheme *runt
 		sts.Spec.Replicas = &replicas
 		sts.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
 		sts.Spec.Template.Labels = labels
+		sts.Spec.Template.Spec.Affinity = softPodAntiAffinity(labels)
 
 		useMemory := parseBoolEnv(operatorEtcdStorageMemoryEnv)
 		if useMemory {

--- a/test/chart/proxy-antiaffinity_test.sh
+++ b/test/chart/proxy-antiaffinity_test.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Copyright 2026 KafScale team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Chart template test for the proxy Deployment default podAntiAffinity.
+#
+# The default anti-affinity rule only spreads replicas if its label selector
+# matches the proxy's own pod labels. A selector hardcoded to "kafscale-proxy"
+# silently matches nothing under nameOverride (the pod label becomes
+# "<override>-proxy"), disabling HA with no error. This test asserts that the
+# rendered anti-affinity selector EQUALS the rendered pod-template labels, in
+# the default case AND under --set nameOverride=foo (the case that would have
+# caught the drift). It also asserts that an explicit proxy.affinity replaces
+# the default. Self-contained: needs only helm and awk, no helm plugins. Run
+# directly or via `make test-chart-antiaffinity`.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHART_DIR="${ROOT_DIR}/deploy/helm/kafscale"
+
+command -v helm >/dev/null 2>&1 || { echo "helm is required"; exit 1; }
+
+fail=0
+
+render_proxy() {
+  helm template kafscale "${CHART_DIR}" \
+    --show-only templates/proxy-deployment.yaml \
+    --set proxy.enabled=true \
+    "$@"
+}
+
+# Extract the three app.kubernetes.io label values (name/instance/component)
+# from a given YAML block. We scope to a section by streaming the lines that
+# belong to it. The values are emitted as "name=..,instance=..,component=.."
+# so two blocks can be compared as a single string.
+labels_triplet() {
+  awk '
+    /app\.kubernetes\.io\/name:/      { name=$2 }
+    /app\.kubernetes\.io\/instance:/  { inst=$2 }
+    /app\.kubernetes\.io\/component:/ { comp=$2 }
+    END { printf "name=%s,instance=%s,component=%s", name, inst, comp }
+  '
+}
+
+# The pod-template label block: lines after "  template:" up to (not including)
+# the "    spec:" line. Within that we read the matchLabels-free label map.
+pod_template_labels() {
+  render_proxy "$@" | awk '
+    /^  template:/ { intpl=1; next }
+    intpl && /^    spec:/ { intpl=0 }
+    intpl { print }
+  ' | labels_triplet
+}
+
+# The anti-affinity selector label block: lines after the podAntiAffinity
+# "matchLabels:" up to the "topologyKey:" line.
+antiaffinity_selector_labels() {
+  render_proxy "$@" | awk '
+    /matchLabels:/   { insel=1; next }
+    insel && /topologyKey:/ { insel=0 }
+    insel { print }
+  ' | labels_triplet
+}
+
+# Whether the render contains a soft (preferredDuring) podAntiAffinity at all.
+has_soft_antiaffinity() {
+  render_proxy "$@" | grep -q "preferredDuringSchedulingIgnoredDuringExecution"
+}
+
+assert_eq() {
+  local desc="$1" want="$2" got="$3"
+  if [ "${got}" = "${want}" ]; then
+    echo "PASS: ${desc}"
+  else
+    echo "FAIL: ${desc}"
+    echo "       want: ${want}"
+    echo "       got:  ${got}"
+    fail=1
+  fi
+}
+
+assert_true() {
+  local desc="$1"; shift
+  if "$@"; then
+    echo "PASS: ${desc}"
+  else
+    echo "FAIL: ${desc}"
+    fail=1
+  fi
+}
+
+assert_false() {
+  local desc="$1"; shift
+  if "$@"; then
+    echo "FAIL: ${desc}"
+    fail=1
+  else
+    echo "PASS: ${desc}"
+  fi
+}
+
+echo "==> chart proxy anti-affinity template test"
+
+# Case 1: default install. Selector must equal the pod labels (kafscale-proxy).
+pod="$(pod_template_labels)"
+sel="$(antiaffinity_selector_labels)"
+assert_eq "default: anti-affinity selector equals pod labels" "${pod}" "${sel}"
+assert_eq "default: selector targets the proxy pods" "name=kafscale-proxy,instance=kafscale,component=proxy" "${sel}"
+
+# Case 2: nameOverride=foo. The pod label name becomes foo-proxy; the selector
+# must move with it. The old hardcoded "kafscale-proxy" selector would fail here.
+pod_ov="$(pod_template_labels --set nameOverride=foo)"
+sel_ov="$(antiaffinity_selector_labels --set nameOverride=foo)"
+assert_eq "nameOverride=foo: anti-affinity selector equals pod labels" "${pod_ov}" "${sel_ov}"
+assert_eq "nameOverride=foo: selector tracks the overridden name" "name=foo-proxy,instance=kafscale,component=proxy" "${sel_ov}"
+
+# Case 3: soft-only. The default must be preferredDuring (never requiredDuring),
+# so single-node clusters still schedule every replica.
+assert_true  "default anti-affinity is soft (preferredDuring present)" has_soft_antiaffinity
+assert_false "default anti-affinity is not hard (requiredDuring absent)" \
+  bash -c 'helm template kafscale "'"${CHART_DIR}"'" --show-only templates/proxy-deployment.yaml --set proxy.enabled=true | grep -q requiredDuringSchedulingIgnoredDuringExecution'
+
+# Case 4: explicit proxy.affinity replaces the default (no podAntiAffinity).
+assert_false "explicit proxy.affinity replaces the default soft anti-affinity" \
+  has_soft_antiaffinity --set 'proxy.affinity.nodeAffinity.foo=bar'
+
+if [ "${fail}" -ne 0 ]; then
+  echo "==> chart proxy anti-affinity template test FAILED"
+  exit 1
+fi
+echo "==> chart proxy anti-affinity template test passed"


### PR DESCRIPTION
## What

Add soft (preferred) pod anti-affinity so replicas of the same component avoid co-locating on one node:

- operator-managed broker and etcd StatefulSets (`pkg/operator`), via a shared `softPodAntiAffinity(labels)` that reuses each workload's pod-template label map as the selector.
- proxy Deployment (chart): a default soft anti-affinity templated into `proxy-deployment.yaml`, applied only when `proxy.affinity` is empty.

All terms are soft (`preferredDuringSchedulingIgnoredDuringExecution`), so single-node clusters still schedule every replica. Flip to required in multi-node production by setting an explicit affinity.

## Why

Without it the scheduler can place all replicas of a component on one node, so a single node loss takes the whole quorum (broker or etcd) or the only ingress (proxy) at once, defeating the replication. Soft anti-affinity is the standard HA default and stays safe on single-node clusters.

## Selector-drift fix (review follow-up)

The earlier revision hardcoded the proxy default anti-affinity selector to `app.kubernetes.io/name: kafscale-proxy` in `values.yaml`. Under `nameOverride` the proxy pod label becomes `<override>-proxy`, so the selector matched nothing: the rule was present but spread no pods, disabling HA with no error.

The fix moves the default into `proxy-deployment.yaml` and templates the selector from the same `componentSelectorLabels` helper that produces the pod labels. The selector now always matches the proxy's own pods, including under `nameOverride`/`fullnameOverride`. The operator path already used this property (the StatefulSet selector reuses the pod-template label map); the chart now matches that discipline.

## Test

Two concrete, runnable artefacts. No cluster required for either.

**Operator unit test** (`pkg/operator/antiaffinity_test.go`): reconciles a `KafscaleCluster` against the fake client, fetches the broker and etcd StatefulSets, and asserts that

- `Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0].PodAffinityTerm.LabelSelector.MatchLabels` EQUALS the pod-template labels, and
- `TopologyKey == "kubernetes.io/hostname"`, and
- the term is soft-only (no required term).

That equality is the property that makes the rule work: the selector targets the very pods it is meant to spread.

```
go test ./pkg/operator/... -run AntiAffinity -v
```

**Chart template assertion** (`test/chart/proxy-antiaffinity_test.sh`, run via `make test-chart-antiaffinity`): renders the proxy Deployment with `helm template` and asserts the anti-affinity selector EQUALS the rendered pod labels in the default case AND under `--set nameOverride=foo` (the case that would have caught the drift), plus soft-only and user-override checks.

```
make test-chart-antiaffinity
```

Both pass on this branch. `helm lint deploy/helm/kafscale` is clean and `go build ./...` is green.

## Reproducible before/after (live evidence recipe)

A live multi-node capture is pending lab availability. In the meantime this recipe reproduces the effect on any host with kind:

```bash
# 3-node kind cluster
cat <<'EOF' > /tmp/kind-3node.yaml
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
  - role: control-plane
  - role: worker
  - role: worker
EOF
kind create cluster --name aa-demo --config /tmp/kind-3node.yaml

# BEFORE: a 3-replica Deployment with no anti-affinity can co-locate.
kubectl create deployment demo --image=registry.k8s.io/pause:3.9 --replicas=3
kubectl get pods -l app=demo -o wide          # observe replicas sharing nodes

# AFTER: add the same soft anti-affinity this PR ships and let the
# scheduler re-place. Replicas prefer distinct nodes.
kubectl patch deployment demo --type merge -p '{
  "spec": {"template": {"spec": {"affinity": {"podAntiAffinity": {
    "preferredDuringSchedulingIgnoredDuringExecution": [{
      "weight": 100,
      "podAffinityTerm": {
        "labelSelector": {"matchLabels": {"app": "demo"}},
        "topologyKey": "kubernetes.io/hostname"}}]}}}}}}'
kubectl rollout status deployment/demo
kubectl get pods -l app=demo -o wide          # replicas now spread across nodes

kind delete cluster --name aa-demo
```

For the real chart, the equivalent check is: install the chart on a 3-node cluster with `proxy.replicaCount=2` (or a 3-broker `KafscaleCluster`) and run `kubectl get pods -o wide`; the proxy replicas (and broker/etcd pods) land on distinct nodes where capacity allows.

## Scope decisions

- **Dropped** the empty `topologySpreadConstraints: []` values hook: it added surface with no default behavior and no test. Possible follow-up if a multi-zone default is wanted.
- **Operator-set affinity is not yet overridable via the CR.** A clean passthrough would need new `Affinity` fields on `BrokerSpec`/`EtcdSpec` plus CRD regeneration, which is out of scope for this single-purpose PR. Tracked as a follow-up.

## Backward-compat note

`proxy.affinity` returns to a `{}` default and the chart now supplies the default soft anti-affinity in the template. Setting `proxy.affinity` REPLACES the chart default rather than merging with it. Users who want anti-affinity plus extra affinity rules should include the anti-affinity block in their override.

Part of a small series upstreaming deployment-hardening deltas we currently carry.
