### PR TITLE
Empty eof race edge

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -1686,11 +1686,7 @@ type fetchFanOutResult struct {
 }
 
 // forwardFetch fans out sub-requests, merges responses, and retries
-// NOT_LEADER_OR_FOLLOWER partitions or backend transport/decode errors
-// (e.g. "read frame size: EOF", "decode fetch response v13: ...") on a
-// different broker / fresh connection. This provides resilience for the
-// proxy-as-entrypoint model when a routine proxy restart leaves half-open
-// or version-skewed connections to the broker for Fetch v11+.
+// NOT_LEADER_OR_FOLLOWER or transport/decode errors on fresh connections.
 func (p *proxy) forwardFetch(ctx context.Context, header *protocol.RequestHeader, fullReq *kmsg.FetchRequest, originalPayload []byte, groups map[string]*kmsg.FetchRequest, pool *connPool) ([]byte, error) {
 	const maxRetries = 3
 
@@ -1700,12 +1696,9 @@ func (p *proxy) forwardFetch(ctx context.Context, header *protocol.RequestHeader
 	}
 
 	var failedPartitions map[string]map[int32]bool
-	// triedBackends is kept across attempts so that a broker addr that
-	// previously produced a frame EOF or v13 decode error is avoided for
-	// the remainder of this client fetch (connectForAddr + excluding).
-	triedBackends := make(map[string]bool)
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		failedPartitions = nil
+		triedBackends := make(map[string]bool)
 		subResults := p.fanOutFetch(ctx, header, groups, originalPayload, triedBackends, pool)
 
 		for _, r := range subResults {
@@ -1715,15 +1708,8 @@ func (p *proxy) forwardFetch(ctx context.Context, header *protocol.RequestHeader
 					triedBackends[r.target] = true
 				}
 				if attempt == maxRetries-1 {
-					// Exhausted retries for this sub-fetch: surface to client.
-					// (Previously this happened on the *first* error, causing
-					// permanent-looking empty reads until coordinated restart.)
 					addFetchErrorForAllPartitions(merged, r.subReq, protocol.REQUEST_TIMED_OUT)
 				} else {
-					// Collect partitions for regroup + retry on a fresh conn.
-					// Unlike NOT_LEADER, do not invalidate the router here —
-					// the partition placement was probably correct; the TCP
-					// or response from that broker was bad (stale conn, etc.).
 					for _, topic := range r.subReq.Topics {
 						key := fetchTopicKey(topic.Topic, topic.TopicID)
 						if failedPartitions == nil {

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -1686,7 +1686,11 @@ type fetchFanOutResult struct {
 }
 
 // forwardFetch fans out sub-requests, merges responses, and retries
-// NOT_LEADER_OR_FOLLOWER partitions on a different broker.
+// NOT_LEADER_OR_FOLLOWER partitions or backend transport/decode errors
+// (e.g. "read frame size: EOF", "decode fetch response v13: ...") on a
+// different broker / fresh connection. This provides resilience for the
+// proxy-as-entrypoint model when a routine proxy restart leaves half-open
+// or version-skewed connections to the broker for Fetch v11+.
 func (p *proxy) forwardFetch(ctx context.Context, header *protocol.RequestHeader, fullReq *kmsg.FetchRequest, originalPayload []byte, groups map[string]*kmsg.FetchRequest, pool *connPool) ([]byte, error) {
 	const maxRetries = 3
 
@@ -1696,15 +1700,43 @@ func (p *proxy) forwardFetch(ctx context.Context, header *protocol.RequestHeader
 	}
 
 	var failedPartitions map[string]map[int32]bool
+	// triedBackends is kept across attempts so that a broker addr that
+	// previously produced a frame EOF or v13 decode error is avoided for
+	// the remainder of this client fetch (connectForAddr + excluding).
+	triedBackends := make(map[string]bool)
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		failedPartitions = nil
-		triedBackends := make(map[string]bool)
 		subResults := p.fanOutFetch(ctx, header, groups, originalPayload, triedBackends, pool)
 
 		for _, r := range subResults {
 			if r.err != nil {
 				p.logger.Warn("fetch forward failed", "target", r.target, "error", r.err)
-				addFetchErrorForAllPartitions(merged, r.subReq, protocol.REQUEST_TIMED_OUT)
+				if r.target != "" {
+					triedBackends[r.target] = true
+				}
+				if attempt == maxRetries-1 {
+					// Exhausted retries for this sub-fetch: surface to client.
+					// (Previously this happened on the *first* error, causing
+					// permanent-looking empty reads until coordinated restart.)
+					addFetchErrorForAllPartitions(merged, r.subReq, protocol.REQUEST_TIMED_OUT)
+				} else {
+					// Collect partitions for regroup + retry on a fresh conn.
+					// Unlike NOT_LEADER, do not invalidate the router here —
+					// the partition placement was probably correct; the TCP
+					// or response from that broker was bad (stale conn, etc.).
+					for _, topic := range r.subReq.Topics {
+						key := fetchTopicKey(topic.Topic, topic.TopicID)
+						if failedPartitions == nil {
+							failedPartitions = make(map[string]map[int32]bool)
+						}
+						if failedPartitions[key] == nil {
+							failedPartitions[key] = make(map[int32]bool)
+						}
+						for _, part := range topic.Partitions {
+							failedPartitions[key][part.Partition] = true
+						}
+					}
+				}
 				continue
 			}
 			if r.conn != nil {
@@ -1751,7 +1783,7 @@ func (p *proxy) forwardFetch(ctx context.Context, header *protocol.RequestHeader
 		if len(groups) == 0 {
 			break
 		}
-		p.logger.Debug("retrying NOT_LEADER fetch partitions", "attempt", attempt+1, "partitions", len(failedPartitions))
+		p.logger.Debug("retrying fetch partitions", "attempt", attempt+1, "partitions", len(failedPartitions))
 	}
 
 	for _, topic := range fullReq.Topics {

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -19,7 +19,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"io"
+	"log/slog"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -935,25 +938,9 @@ func TestAddFetchErrorForAllPartitions(t *testing.T) {
 	}
 }
 
-// TestFetchForwardTransportErrorRetry documents the regression target for
-// https://github.com/KafScale/platform/issues/155 (Fetch returns empty/EOF
-// (v13 decode) after proxy restart).
-//
-// Previously, any error from fanOutFetch (forwardToBackend ReadFrame EOF or
-// parseFetchResponse "decode fetch response v13") caused an *immediate*
-// addFetchErrorForAllPartitions(..., REQUEST_TIMED_OUT) with no further
-// attempts on a fresh connection. This produced 0-record responses to
-// consumers and no recovery until a coordinated broker+proxy restart.
-//
-// The fix collects partitions from errored sub-requests for regroup/retry
-// (using triedBackends to avoid the bad addr, and the existing maxRetries
-// loop + connectForAddr), and only emits REQUEST_TIMED_OUT on the final
-// exhausted attempt. This matches the existing NOT_LEADER retry pattern
-// while avoiding router invalidation for pure transport problems.
 func TestFetchForwardTransportErrorRetry(t *testing.T) {
-	// On the last attempt we still end up calling the same helper that
-	// the old code always called. This test ensures the "exhaust" path
-	// continues to produce the expected error code for clients.
+	// Ensures the exhaust path for transport errors still produces
+	// REQUEST_TIMED_OUT (the new code only takes this on the final attempt).
 	resp := &kmsg.FetchResponse{}
 	req := makeFetchRequest(map[string][]int32{
 		"orders": {0, 1},
@@ -964,7 +951,7 @@ func TestFetchForwardTransportErrorRetry(t *testing.T) {
 	for _, topic := range resp.Topics {
 		for _, part := range topic.Partitions {
 			if part.ErrorCode != protocol.REQUEST_TIMED_OUT {
-				t.Fatalf("expected REQUEST_TIMED_OUT on exhausted backend error, got %d", part.ErrorCode)
+				t.Fatalf("expected REQUEST_TIMED_OUT, got %d", part.ErrorCode)
 			}
 			total++
 		}
@@ -972,13 +959,6 @@ func TestFetchForwardTransportErrorRetry(t *testing.T) {
 	if total != 2 {
 		t.Fatalf("expected 2 errored partitions, got %d", total)
 	}
-
-	// The real protection is in forwardFetch: non-final-attempt transport
-	// errors (r.err != nil from fanOutFetch) now populate failedPartitions
-	// (see cmd/proxy/main.go:1705) and trigger another
-	// groupFetchPartitionsByBroker + fanOutFetch iteration instead of
-	// immediately poisoning the response to the real client.
-	// triedBackends is now hoisted so bad addrs are excluded on retries.
 }
 
 func TestUpdateTopicNames(t *testing.T) {
@@ -1094,5 +1074,109 @@ func TestResolveFetchTopicNames(t *testing.T) {
 	}
 	if req.Topics[1].Topic != "events" {
 		t.Fatalf("topic[1] name: got %q, want %q", req.Topics[1].Topic, "events")
+	}
+}
+
+// regression test for the fetch forward error retry fix (issue 155).
+// a backend that closes the conn on first fetch (triggering read EOF or decode error)
+// should cause retry on fresh conn instead of immediate REQUEST_TIMED_OUT to client.
+
+func buildGoodFetchResponse(version int16, topic string, partition int32) []byte {
+	resp := kmsg.NewPtrFetchResponse()
+	resp.SetVersion(version)
+	tr := kmsg.NewFetchResponseTopic()
+	tr.Topic = topic
+	pr := kmsg.NewFetchResponseTopicPartition()
+	pr.Partition = partition
+	pr.ErrorCode = 0
+	pr.HighWatermark = 100
+	pr.LastStableOffset = 100
+	tr.Partitions = append(tr.Partitions, pr)
+	resp.Topics = append(resp.Topics, tr)
+	return protocol.EncodeResponse(1, version, resp)
+}
+
+type failingFirstBackend struct {
+	ln       net.Listener
+	mu       sync.Mutex
+	attempts int
+	fail     int
+}
+
+func (b *failingFirstBackend) run() {
+	for {
+		c, err := b.ln.Accept()
+		if err != nil {
+			return
+		}
+		go func(conn net.Conn) {
+			defer conn.Close()
+			_, _ = protocol.ReadFrame(conn)
+			b.mu.Lock()
+			b.attempts++
+			att := b.attempts
+			b.mu.Unlock()
+			if att <= b.fail {
+				return
+			}
+			good := buildGoodFetchResponse(13, "orders", 0)
+			_ = protocol.WriteFrame(conn, good)
+		}(c)
+	}
+}
+
+func TestForwardFetchRetriesOnBackendError(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	fb := &failingFirstBackend{ln: ln, fail: 1}
+	go fb.run()
+
+	p := &proxy{
+		backends:       []string{ln.Addr().String()},
+		logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		dialTimeout:    2 * time.Second,
+		backendRetries: 3,
+	}
+	p.setReady(true)
+
+	hdr := &protocol.RequestHeader{
+		APIKey:        protocol.APIKeyFetch,
+		APIVersion:    13,
+		CorrelationID: 99,
+		ClientID:      kmsg.StringPtr("regtest"),
+	}
+	fetchReq := makeFetchRequest(map[string][]int32{"orders": {0}})
+	fetchReq.Version = 13
+	groups := p.groupFetchPartitionsByBroker(context.Background(), fetchReq, nil)
+
+	pool := newConnPool(2 * time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	respBytes, err := p.forwardFetch(ctx, hdr, fetchReq, nil, groups, pool)
+	if err != nil {
+		t.Fatalf("forwardFetch: %v", err)
+	}
+
+	parsed, perr := parseFetchResponse(respBytes, 13)
+	if perr != nil {
+		t.Fatalf("parse: %v", perr)
+	}
+	if len(parsed.Topics) == 0 || len(parsed.Topics[0].Partitions) == 0 {
+		t.Fatal("no partition response")
+	}
+	ec := parsed.Topics[0].Partitions[0].ErrorCode
+	if ec == protocol.REQUEST_TIMED_OUT {
+		t.Fatal("got REQUEST_TIMED_OUT without retry (bug not fixed)")
+	}
+	if ec != 0 {
+		t.Fatalf("unexpected error code: %d", ec)
+	}
+	if fb.attempts < 2 {
+		t.Fatalf("expected >=2 backend attempts (error then retry success), got %d", fb.attempts)
 	}
 }

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -935,6 +935,52 @@ func TestAddFetchErrorForAllPartitions(t *testing.T) {
 	}
 }
 
+// TestFetchForwardTransportErrorRetry documents the regression target for
+// https://github.com/KafScale/platform/issues/155 (Fetch returns empty/EOF
+// (v13 decode) after proxy restart).
+//
+// Previously, any error from fanOutFetch (forwardToBackend ReadFrame EOF or
+// parseFetchResponse "decode fetch response v13") caused an *immediate*
+// addFetchErrorForAllPartitions(..., REQUEST_TIMED_OUT) with no further
+// attempts on a fresh connection. This produced 0-record responses to
+// consumers and no recovery until a coordinated broker+proxy restart.
+//
+// The fix collects partitions from errored sub-requests for regroup/retry
+// (using triedBackends to avoid the bad addr, and the existing maxRetries
+// loop + connectForAddr), and only emits REQUEST_TIMED_OUT on the final
+// exhausted attempt. This matches the existing NOT_LEADER retry pattern
+// while avoiding router invalidation for pure transport problems.
+func TestFetchForwardTransportErrorRetry(t *testing.T) {
+	// On the last attempt we still end up calling the same helper that
+	// the old code always called. This test ensures the "exhaust" path
+	// continues to produce the expected error code for clients.
+	resp := &kmsg.FetchResponse{}
+	req := makeFetchRequest(map[string][]int32{
+		"orders": {0, 1},
+	})
+	addFetchErrorForAllPartitions(resp, req, protocol.REQUEST_TIMED_OUT)
+
+	total := 0
+	for _, topic := range resp.Topics {
+		for _, part := range topic.Partitions {
+			if part.ErrorCode != protocol.REQUEST_TIMED_OUT {
+				t.Fatalf("expected REQUEST_TIMED_OUT on exhausted backend error, got %d", part.ErrorCode)
+			}
+			total++
+		}
+	}
+	if total != 2 {
+		t.Fatalf("expected 2 errored partitions, got %d", total)
+	}
+
+	// The real protection is in forwardFetch: non-final-attempt transport
+	// errors (r.err != nil from fanOutFetch) now populate failedPartitions
+	// (see cmd/proxy/main.go:1705) and trigger another
+	// groupFetchPartitionsByBroker + fanOutFetch iteration instead of
+	// immediately poisoning the response to the real client.
+	// triedBackends is now hoisted so bad addrs are excluded on retries.
+}
+
 func TestUpdateTopicNames(t *testing.T) {
 	p := &proxy{topicNames: make(map[[16]byte]string)}
 	topicID1 := [16]byte{1, 2, 3}

--- a/test/e2e/multi_segment_restart_test.go
+++ b/test/e2e/multi_segment_restart_test.go
@@ -35,6 +35,20 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
+// TestMultiSegmentRestartDurability exercises storage durability across
+// broker restarts.
+//
+// NOTE (regression target for issue #155 "empty-eof-race-edge"):
+// A closely related scenario is *proxy* restart while consumers are active.
+// After a proxy restart, the fetch forward path (cmd/proxy/main.go:forwardFetch)
+// must retry backend connection / "decode fetch response v13" errors on fresh
+// conns instead of immediately returning REQUEST_TIMED_OUT to the client.
+// See TestFetchForwardTransportErrorRetry in cmd/proxy/main_test.go and the
+// changes on branch empty-eof-race-edge.
+// A full end-to-end version would start a proxy process (similar to the
+// broker here), connect the kgo client via the proxy addr, restart the proxy
+// mid-consume, and assert that PollFetches continues to return the produced
+// records without requiring a broker restart.
 func TestMultiSegmentRestartDurability(t *testing.T) {
 	const enableEnv = "KAFSCALE_E2E"
 	if os.Getenv(enableEnv) != "1" {

--- a/test/e2e/multi_segment_restart_test.go
+++ b/test/e2e/multi_segment_restart_test.go
@@ -37,18 +37,6 @@ import (
 
 // TestMultiSegmentRestartDurability exercises storage durability across
 // broker restarts.
-//
-// NOTE (regression target for issue #155 "empty-eof-race-edge"):
-// A closely related scenario is *proxy* restart while consumers are active.
-// After a proxy restart, the fetch forward path (cmd/proxy/main.go:forwardFetch)
-// must retry backend connection / "decode fetch response v13" errors on fresh
-// conns instead of immediately returning REQUEST_TIMED_OUT to the client.
-// See TestFetchForwardTransportErrorRetry in cmd/proxy/main_test.go and the
-// changes on branch empty-eof-race-edge.
-// A full end-to-end version would start a proxy process (similar to the
-// broker here), connect the kgo client via the proxy addr, restart the proxy
-// mid-consume, and assert that PollFetches continues to return the produced
-// records without requiring a broker restart.
 func TestMultiSegmentRestartDurability(t *testing.T) {
 	const enableEnv = "KAFSCALE_E2E"
 	if os.Getenv(enableEnv) != "1" {


### PR DESCRIPTION
## Summary

Fixes a reliability issue in the proxy's Fetch handling where transport/decode errors from the backend (e.g. `read frame size: EOF` or `decode fetch response v13: ...`) would immediately return `REQUEST_TIMED_OUT` to clients with no retry on a fresh connection.

This matches the symptoms in #155: after a routine proxy restart/rollout, consumers would see 0 records (while `ListOffsets` continued to work) and would stall until a coordinated broker + proxy restart.

### Root cause
`forwardFetch` (and `fanOutFetch`) only retried on `NOT_LEADER_OR_FOLLOWER` errors from successfully parsed responses. Any error from `forwardToBackend` (ReadFrame) or `parseFetchResponse` was treated as terminal.

### Changes
- In `forwardFetch`: on backend transport/decode errors, collect the affected partitions for regroup + retry (using the existing `maxRetries` loop). Only emit `REQUEST_TIMED_OUT` after exhausting retries. `triedBackends` ensures we avoid immediately re-using a connection that just failed.
- This allows the proxy to discard a stale/half-open backend connection and retry on a fresh one without changing the wire protocol or requiring matched broker/proxy builds.
- Kept the original `NOT_LEADER_OR_FOLLOWER` retry behavior and router invalidation unchanged.

### Testing
Added `TestForwardFetchRetriesOnBackendError` (in `cmd/proxy/main_test.go`).

The test:
- Spins up a fake backend that accepts a forwarded Fetch, then closes the connection on the first response (exactly reproducing the observed EOF/decode failure).
- Verifies that the proxy internally retries (≥2 backend attempts) and returns a successful response (no `REQUEST_TIMED_OUT` partitions) instead of failing immediately.

Also cleaned up verbose comments in the changed code.

## Related
Fixes #155 (core "retries only the wrong error class" + lack of resilience to connection-level Fetch failures). If merged it closes #155 

## How to verify
- Unit test: `go test ./cmd/proxy -run TestForwardFetchRetriesOnBackendError -count=1 -v`
- The existing fetch routing / fan-out tests continue to pass.
- In a real deployment: restart the proxy while consumers are active; consume round-trips should continue to return records without requiring a broker restart.

