### PR TITLE
fix: recover proxy metadata after slow etcd cold start (#158)

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -352,7 +352,7 @@ func (p *proxy) checkReady(ctx context.Context) bool {
 	if len(p.backends) > 0 {
 		return true
 	}
-	if p.cacheFresh() {
+	if p.cacheFresh() && len(p.cachedBackendsSnapshot()) > 0 {
 		return true
 	}
 	if p.store == nil {
@@ -369,9 +369,9 @@ func (p *proxy) initMetadataCache(ctx context.Context) {
 		return
 	}
 	p.refreshMetadataCache(ctx)
-	// Periodic refresh so topology changes are picked up without a cache miss.
+	// Periodic refresh pulls from etcd so cold-start races self-heal without restart.
 	go func() {
-		ticker := time.NewTicker(30 * time.Second)
+		ticker := time.NewTicker(10 * time.Second)
 		defer ticker.Stop()
 		for {
 			select {
@@ -1390,17 +1390,12 @@ func (p *proxy) currentBackends(ctx context.Context) ([]string, error) {
 	if len(p.backends) > 0 {
 		return p.backends, nil
 	}
+	p.syncStoreSnapshot(ctx)
 	meta, err := p.store.Metadata(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
-	addrs := make([]string, 0, len(meta.Brokers))
-	for _, broker := range meta.Brokers {
-		if broker.Host == "" || broker.Port == 0 {
-			continue
-		}
-		addrs = append(addrs, fmt.Sprintf("%s:%d", broker.Host, broker.Port))
-	}
+	addrs := brokerAddrsFromMetadata(meta.Brokers)
 	if len(addrs) > 0 {
 		p.setCachedBackends(addrs)
 		p.touchHealthy()
@@ -1425,6 +1420,15 @@ func (p *proxy) updateBrokerAddrs(brokers []protocol.MetadataBroker) {
 	p.brokerAddrMu.Unlock()
 }
 
+// syncStoreSnapshot reloads the etcd metadata snapshot when the store supports it.
+func (p *proxy) syncStoreSnapshot(ctx context.Context) {
+	if etcdStore, ok := p.store.(*metadata.EtcdStore); ok {
+		if err := etcdStore.RefreshSnapshot(ctx); err != nil {
+			p.logger.Warn("metadata snapshot sync failed", "error", err)
+		}
+	}
+}
+
 // refreshMetadataCache updates broker address and topic name caches from
 // metadata. Concurrent calls are coalesced via singleflight. Uses a detached
 // context so that a single caller's cancellation does not abort the shared fetch.
@@ -1435,18 +1439,34 @@ func (p *proxy) refreshMetadataCache(ctx context.Context) {
 	fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 	defer cancel()
 	_, err, _ := p.metaFlight.Do("refresh", func() (interface{}, error) {
+		p.syncStoreSnapshot(fetchCtx)
 		meta, err := p.store.Metadata(fetchCtx, nil)
 		if err != nil {
 			return nil, err
 		}
 		p.updateBrokerAddrs(meta.Brokers)
 		p.updateTopicNames(meta.Topics)
-		p.touchHealthy()
+		if addrs := brokerAddrsFromMetadata(meta.Brokers); len(addrs) > 0 {
+			p.setCachedBackends(addrs)
+			p.touchHealthy()
+			p.setReady(true)
+		}
 		return nil, nil
 	})
 	if err != nil {
 		p.logger.Warn("metadata cache refresh failed", "error", err)
 	}
+}
+
+func brokerAddrsFromMetadata(brokers []protocol.MetadataBroker) []string {
+	addrs := make([]string, 0, len(brokers))
+	for _, broker := range brokers {
+		if broker.Host == "" || broker.Port == 0 {
+			continue
+		}
+		addrs = append(addrs, fmt.Sprintf("%s:%d", broker.Host, broker.Port))
+	}
+	return addrs
 }
 
 func (p *proxy) updateTopicNames(topics []protocol.MetadataTopic) {

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"net"
@@ -26,9 +27,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/KafScale/platform/internal/testutil"
 	"github.com/KafScale/platform/pkg/metadata"
 	"github.com/KafScale/platform/pkg/protocol"
 	"github.com/twmb/franz-go/pkg/kmsg"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 func TestBuildProxyMetadataResponseRewritesBrokers(t *testing.T) {
@@ -1178,5 +1181,109 @@ func TestForwardFetchRetriesOnBackendError(t *testing.T) {
 	}
 	if fb.attempts < 2 {
 		t.Fatalf("expected >=2 backend attempts (error then retry success), got %d", fb.attempts)
+	}
+}
+
+func TestCheckReadyNotReadyWithEmptySnapshot(t *testing.T) {
+	endpoints := testutil.StartEmbeddedEtcd(t)
+	ctx := context.Background()
+
+	store, err := metadata.NewEtcdStore(ctx, metadata.ClusterMetadata{}, metadata.EtcdStoreConfig{Endpoints: endpoints})
+	if err != nil {
+		t.Fatalf("NewEtcdStore: %v", err)
+	}
+
+	p := &proxy{
+		store:    store,
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cacheTTL: 60 * time.Second,
+	}
+
+	p.refreshMetadataCache(ctx)
+	if p.checkReady(ctx) {
+		t.Fatal("expected not ready with empty etcd snapshot")
+	}
+
+	// Simulate the old bug: touchHealthy without backends should not satisfy readiness.
+	p.touchHealthy()
+	if p.checkReady(ctx) {
+		t.Fatal("expected not ready when cache is fresh but no backends are cached")
+	}
+}
+
+func TestRefreshMetadataCacheRecoversAfterEtcdSlowStart(t *testing.T) {
+	endpoints := testutil.StartEmbeddedEtcd(t)
+	ctx := context.Background()
+
+	store, err := metadata.NewEtcdStore(ctx, metadata.ClusterMetadata{}, metadata.EtcdStoreConfig{Endpoints: endpoints})
+	if err != nil {
+		t.Fatalf("NewEtcdStore: %v", err)
+	}
+
+	p := &proxy{
+		store:    store,
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cacheTTL: 60 * time.Second,
+	}
+
+	p.refreshMetadataCache(ctx)
+	if p.checkReady(ctx) {
+		t.Fatal("expected not ready before operator publishes snapshot")
+	}
+
+	late := metadata.ClusterMetadata{
+		Brokers: []protocol.MetadataBroker{
+			{NodeID: 0, Host: "broker-0", Port: 9092},
+		},
+		ControllerID: 0,
+		Topics: []protocol.MetadataTopic{
+			{
+				Topic: kmsg.StringPtr("events"),
+				Partitions: []protocol.MetadataPartition{
+					{Partition: 0, Leader: 0},
+				},
+			},
+		},
+	}
+	putProxyTestSnapshot(t, endpoints, late)
+
+	p.refreshMetadataCache(ctx)
+	if !p.checkReady(ctx) {
+		t.Fatal("expected ready after snapshot sync from etcd")
+	}
+	if cached := p.cachedBackendsSnapshot(); len(cached) != 1 || cached[0] != "broker-0:9092" {
+		t.Fatalf("unexpected cached backends: %#v", cached)
+	}
+}
+
+func TestCheckReadyWithStaticBackends(t *testing.T) {
+	p := &proxy{
+		backends: []string{"broker-0:9092"},
+		cacheTTL: 60 * time.Second,
+	}
+	if !p.checkReady(context.Background()) {
+		t.Fatal("expected ready when static backends are configured")
+	}
+}
+
+func putProxyTestSnapshot(t *testing.T, endpoints []string, snap metadata.ClusterMetadata) {
+	t.Helper()
+	cli, err := clientv3.New(clientv3.Config{
+		Endpoints:   endpoints,
+		DialTimeout: 3 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("new etcd client: %v", err)
+	}
+	defer func() { _ = cli.Close() }()
+
+	payload, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+	putCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := cli.Put(putCtx, "/kafscale/metadata/snapshot", string(payload)); err != nil {
+		t.Fatalf("put snapshot: %v", err)
 	}
 }

--- a/pkg/metadata/etcd_store.go
+++ b/pkg/metadata/etcd_store.go
@@ -94,6 +94,12 @@ func (s *EtcdStore) Metadata(ctx context.Context, topics []string) (*ClusterMeta
 	return s.metadata.Metadata(ctx, topics)
 }
 
+// RefreshSnapshot reloads cluster metadata from etcd. Callers use this to recover
+// when the initial snapshot read failed or the watch stream was interrupted.
+func (s *EtcdStore) RefreshSnapshot(ctx context.Context) error {
+	return s.refreshSnapshot(ctx)
+}
+
 // Available reports whether the most recent etcd operation succeeded.
 func (s *EtcdStore) Available() bool {
 	return atomic.LoadInt32(&s.available) == 1
@@ -474,14 +480,26 @@ func (s *EtcdStore) startWatchers() {
 }
 
 func (s *EtcdStore) watchSnapshot(ctx context.Context) {
-	watchChan := s.client.Watch(ctx, snapshotKey(), clientv3.WithPrefix())
-	for resp := range watchChan {
-		if resp.Err() != nil {
-			continue
+	for {
+		watchChan := s.client.Watch(ctx, snapshotKey(), clientv3.WithPrefix())
+		for resp := range watchChan {
+			if resp.Err() != nil {
+				continue
+			}
+			if err := s.refreshSnapshot(ctx); err != nil {
+				continue
+			}
 		}
-		if err := s.refreshSnapshot(ctx); err != nil {
-			continue
+
+		// Watch channel closed. If the context is done, exit for good.
+		if ctx.Err() != nil {
+			return
 		}
+
+		// Transient failure (etcd leader election, compaction, network blip).
+		// Reseed from a full read and re-establish the watch.
+		time.Sleep(time.Second)
+		_ = s.refreshSnapshot(ctx)
 	}
 }
 

--- a/pkg/metadata/etcd_store_test.go
+++ b/pkg/metadata/etcd_store_test.go
@@ -372,6 +372,109 @@ func TestEtcdStoreNextOffset(t *testing.T) {
 	}
 }
 
+func TestEtcdStoreRefreshSnapshotRecoversAfterLatePublish(t *testing.T) {
+	endpoints := testutil.StartEmbeddedEtcd(t)
+	ctx := context.Background()
+
+	store, err := NewEtcdStore(ctx, ClusterMetadata{}, EtcdStoreConfig{Endpoints: endpoints})
+	if err != nil {
+		t.Fatalf("NewEtcdStore: %v", err)
+	}
+
+	meta, err := store.Metadata(ctx, nil)
+	if err != nil {
+		t.Fatalf("Metadata: %v", err)
+	}
+	if len(meta.Brokers) != 0 {
+		t.Fatalf("expected empty brokers before snapshot publish, got %d", len(meta.Brokers))
+	}
+
+	late := ClusterMetadata{
+		Brokers: []protocol.MetadataBroker{
+			{NodeID: 0, Host: "broker-0", Port: 9092},
+			{NodeID: 1, Host: "broker-1", Port: 9092},
+		},
+		ControllerID: 0,
+		Topics: []protocol.MetadataTopic{
+			{
+				Topic: kmsg.StringPtr("events"),
+				Partitions: []protocol.MetadataPartition{
+					{Partition: 0, Leader: 0},
+				},
+			},
+		},
+	}
+	putSnapshot(t, endpoints, late)
+
+	if err := store.RefreshSnapshot(ctx); err != nil {
+		t.Fatalf("RefreshSnapshot: %v", err)
+	}
+	meta, err = store.Metadata(ctx, nil)
+	if err != nil {
+		t.Fatalf("Metadata after refresh: %v", err)
+	}
+	if len(meta.Brokers) != 2 {
+		t.Fatalf("expected 2 brokers after refresh, got %d", len(meta.Brokers))
+	}
+	if len(meta.Topics) != 1 || *meta.Topics[0].Topic != "events" {
+		t.Fatalf("expected events topic after refresh, got %+v", meta.Topics)
+	}
+}
+
+func TestEtcdStoreWatchSnapshotRecoversAfterLatePublish(t *testing.T) {
+	endpoints := testutil.StartEmbeddedEtcd(t)
+	ctx := context.Background()
+
+	store, err := NewEtcdStore(ctx, ClusterMetadata{}, EtcdStoreConfig{Endpoints: endpoints})
+	if err != nil {
+		t.Fatalf("NewEtcdStore: %v", err)
+	}
+
+	late := ClusterMetadata{
+		Brokers: []protocol.MetadataBroker{
+			{NodeID: 0, Host: "broker-0", Port: 9092},
+		},
+		ControllerID: 0,
+		Topics: []protocol.MetadataTopic{
+			{
+				Topic: kmsg.StringPtr("orders"),
+				Partitions: []protocol.MetadataPartition{
+					{Partition: 0, Leader: 0},
+				},
+			},
+		},
+	}
+	putSnapshot(t, endpoints, late)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		meta, err := store.Metadata(ctx, nil)
+		if err != nil {
+			t.Fatalf("Metadata: %v", err)
+		}
+		if len(meta.Brokers) == 1 && len(meta.Topics) == 1 {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("watch did not pick up late-published snapshot")
+}
+
+func putSnapshot(t *testing.T, endpoints []string, meta ClusterMetadata) {
+	t.Helper()
+	cli := newEtcdClient(t, endpoints)
+	defer func() { _ = cli.Close() }()
+	payload, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+	putCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := cli.Put(putCtx, snapshotKey(), string(payload)); err != nil {
+		t.Fatalf("put snapshot: %v", err)
+	}
+}
+
 func TestEtcdStoreConsumerOffsets(t *testing.T) {
 	endpoints := testutil.StartEmbeddedEtcd(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Fixes #158: proxy does not recover after a slow etcd cold start.

## Problem

If proxy starts before etcd has quorum, it can keep an empty in-memory snapshot. After etcd is healthy, `/readyz` flaps every ~60s and topics stay missing until a manual restart.

## Fix

- Reconnect `EtcdStore` snapshot watches after stream drops
- Force etcd snapshot reload in proxy metadata refresh + backend discovery
- Only mark ready when backends are actually found
- Poll metadata every 10s

## Tests

- Late snapshot publish via `RefreshSnapshot` + watch
- Proxy stays not-ready on empty snapshot
- Proxy recovers after etcd snapshot appears
- Static backends keep `/readyz` ready