### PR TITLE
docs(gh-pages): refresh external access guidance

### DIFF
--- a/_docs/configuration.md
+++ b/_docs/configuration.md
@@ -256,12 +256,17 @@ The proxy provides a single entry point that routes Kafka requests to the approp
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `KAFSCALE_PROXY_ADDR` | `:9092` | Proxy listen address (host:port) |
+| `KAFSCALE_PROXY_HEALTH_ADDR` | `:9094` | Health/readiness listen address (`/readyz`, `/livez`) |
 | `KAFSCALE_PROXY_ADVERTISED_HOST` | | Address clients should connect to |
 | `KAFSCALE_PROXY_ADVERTISED_PORT` | `9092` | Advertised port |
 | `KAFSCALE_PROXY_ETCD_ENDPOINTS` | | etcd endpoints for metadata |
 | `KAFSCALE_PROXY_ETCD_USERNAME` | | etcd basic auth username |
 | `KAFSCALE_PROXY_ETCD_PASSWORD` | | etcd basic auth password |
 | `KAFSCALE_PROXY_BACKENDS` | | Optional comma-separated broker list for static routing |
+| `KAFSCALE_PROXY_BACKEND_CACHE_TTL_SEC` | `60` | Seconds to cache backend metadata before refreshing from etcd |
+| `KAFSCALE_PROXY_BACKEND_BACKOFF_MS` | `500` | Backoff between backend connection retries |
+| `KAFSCALE_PROXY_BACKEND_RETRIES` | `6` | Backend connection retry count |
+| `KAFSCALE_PROXY_LFS_ENABLED` | `false` | Enable the LFS HTTP API on the unified proxy |
 
 The proxy discovers brokers via etcd by default. Use `KAFSCALE_PROXY_BACKENDS` for static configuration:
 
@@ -278,8 +283,9 @@ KAFSCALE_PROXY_BACKENDS=broker-0:9092,broker-1:9092,broker-2:9092
 | `proxy.advertisedHost` | | Public DNS clients should use |
 | `proxy.advertisedPort` | `9092` | Advertised port |
 | `proxy.etcdEndpoints` | | etcd endpoints array |
-| `proxy.service.type` | `ClusterIP` | Service type |
+| `proxy.service.type` | `LoadBalancer` | Service type |
 | `proxy.service.port` | `9092` | Service port |
+| `proxy.service.nodePort` | | Pin NodePort when `type=NodePort` (range `30000–32767`) |
 
 ---
 
@@ -395,11 +401,28 @@ See [Security](/security/) for complete TLS setup instructions.
 
 ---
 
-## External Broker Access
+## External Kafka Access
 
-By default, brokers advertise the in-cluster service DNS name. External clients need a reachable address.
+By default, brokers advertise the in-cluster service DNS name. External clients
+need a reachable address.
 
-### CRD Settings (`spec.brokers`)
+**Recommended:** enable the Helm proxy (`proxy.enabled=true`) and set
+`proxy.advertisedHost`. Clients connect to the proxy Service, not individual
+broker pods. The chart does not ship a Kafka Ingress resource.
+
+**Optional:** expose brokers directly via `spec.brokers` (bypassing the proxy).
+
+### Helm proxy settings
+
+| Value | Default | Description |
+|-------|---------|-------------|
+| `proxy.enabled` | `false` | Deploy the Kafka-aware proxy |
+| `proxy.advertisedHost` | | Public DNS or node IP clients should use |
+| `proxy.advertisedPort` | `9092` | Advertised port |
+| `proxy.service.type` | `LoadBalancer` | `LoadBalancer`, `NodePort`, or `ClusterIP` |
+| `proxy.service.nodePort` | | Pin NodePort when `type=NodePort` |
+
+### CRD Settings (`spec.brokers`) — direct broker exposure
 
 | Field | Description |
 |-------|-------------|

--- a/_docs/helm.md
+++ b/_docs/helm.md
@@ -50,6 +50,19 @@ For a dev/latest install, set `operator.image.useLatest=true`, `console.image.us
 
 After the chart is running you can create a cluster by applying a `KafscaleCluster` resource (see `config/samples/` for an example). The console service is exposed as a ClusterIP by default; enable ingress by toggling `.Values.console.ingress`.
 
+### External Kafka Access
+
+**Recommended:** enable the chart proxy (`proxy.enabled=true`) and set
+`proxy.advertisedHost` to the address external clients should use. The proxy is
+the single Kafka entrypoint and supports broker scaling without client
+reconfiguration. For production, use `proxy.service.type=LoadBalancer`. For
+local clusters (kind), pin `proxy.service.nodePort` (range `30000–32767`).
+
+**Optional:** to expose brokers directly (bypassing the proxy), configure
+`KafscaleCluster` `spec.brokers.service` and `advertisedHost` / `advertisedPort`.
+
+See [Operations](/operations/) for full examples and TLS termination guidance.
+
 ### MCP
 
 The MCP service is optional and disabled by default. Enable it with `mcp.enabled=true`; it will deploy into the dedicated namespace defined by `mcp.namespace.name`.
@@ -63,6 +76,10 @@ The MCP service is optional and disabled by default. Enable it with `mcp.enabled
 | `operator.etcdEndpoints` | List of etcd endpoints the operator will connect to. | `["http://etcd:2379"]` |
 | `console.service.type` | Kubernetes service type for the console. | `ClusterIP` |
 | `console.ingress.*` | Optional ingress configuration for exposing the console. | disabled |
+| `proxy.enabled` | Deploy the Kafka-aware proxy for external client access. | `false` |
+| `proxy.advertisedHost` | Address Kafka clients should connect to (public DNS or node IP). | `""` |
+| `proxy.service.type` | Proxy Service type (`LoadBalancer`, `NodePort`, `ClusterIP`). | `LoadBalancer` |
+| `proxy.service.nodePort` | Pin NodePort when `type=NodePort` (range `30000–32767`). | `""` |
 | `mcp.enabled` | Deploy the MCP service. | `false` |
 | `mcp.namespace.name` | Namespace to deploy the MCP service into. | `kafscale-mcp` |
 | `mcp.ingress.*` | Optional ingress configuration for exposing the MCP service. | disabled |

--- a/_docs/lfs-helm.md
+++ b/_docs/lfs-helm.md
@@ -1,7 +1,7 @@
 ---
 layout: doc
 title: LFS Helm Deployment
-description: Deploy and configure the LFS proxy via the KafScale Helm chart.
+description: Deploy and configure LFS via the KafscaleCluster CRD and Helm chart.
 permalink: /lfs-helm/
 nav_title: LFS Helm
 nav_order: 2
@@ -25,15 +25,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# LFS Proxy Helm Deployment
+# LFS on Kubernetes
 
-The LFS Proxy is deployed as part of the KafScale Helm chart and provides:
+Large File Support (LFS) uses the claim-check pattern: blobs land in S3 and Kafka
+carries a pointer. The **operator** deploys an LFS proxy when you enable
+`spec.lfsProxy` on your `KafscaleCluster`.
 
-- **Kafka Protocol Support**: Transparent claim-check pattern for large messages via Kafka protocol (port 9092)
-- **HTTP API**: RESTful endpoint for browser and SDK uploads (port 8080)
-- **S3 Storage**: Configurable S3-compatible object storage backend
-- **CORS Support**: Configurable cross-origin resource sharing for browser access
-- **Metrics**: Prometheus-compatible metrics endpoint (port 9095)
+Standalone Helm `lfsProxy.*` values were removed in v1.6. Configure LFS on the
+cluster CRD, not via chart values.
 
 ## Prerequisites
 
@@ -44,100 +43,94 @@ The LFS Proxy is deployed as part of the KafScale Helm chart and provides:
 
 ## Installation
 
+1. Install the Helm chart (operator + console):
+
 ```bash
-# Install with LFS proxy enabled
-helm install kafscale deploy/helm/kafscale \
-  -f deploy/helm/kafscale/values-lfs-demo.yaml \
-  --set lfsProxy.enabled=true
+helm upgrade --install kafscale deploy/helm/kafscale \
+  -n kafscale --create-namespace
 ```
 
-## Helm values
-
-### Core settings
+2. Apply a `KafscaleCluster` with LFS enabled:
 
 ```yaml
-lfsProxy:
-  enabled: true
-  replicas: 1
-  image:
-    repository: ghcr.io/kafscale/kafscale-lfs-proxy
-    tag: latest
-
-  # S3 backend.
-  # bucket and region are REQUIRED; the proxy fails to start if either is empty.
-  # The bucket name `kafscale-lfs` is permanently blocklisted at startup
-  # (security fix / PR #139). Use your own name.
-  s3:
-    bucket: my-bucket
-    region: us-east-1
-    endpoint: ""          # Custom endpoint for MinIO
-    pathStyle: false       # Set true for MinIO
-    credentialsSecretRef: s3-credentials
-
-  # HTTP API
-  http:
-    port: 8080
-    corsOrigins: "*"
-    maxUploadSize: 0       # 0 = unlimited
-
-  # Kafka backend
-  kafka:
-    brokers: kafscale-broker:9092
-
-  # Metrics
-  metrics:
+apiVersion: kafscale.io/v1alpha1
+kind: KafscaleCluster
+metadata:
+  name: kafscale
+  namespace: kafscale
+spec:
+  lfsProxy:
     enabled: true
-    port: 9095
-    serviceMonitor:
-      enabled: false
-    prometheusRule:
-      enabled: false
-
-  # Resources
-  resources:
-    requests:
-      cpu: 100m
-      memory: 128Mi
-    limits:
-      cpu: "1"
-      memory: 512Mi
+    http:
+      enabled: true
+      port: 8080
+    s3:
+      bucket: my-bucket
+      region: us-east-1
+      credentialsSecretRef: s3-credentials
+  s3:
+    bucket: kafscale
+    region: us-east-1
+    credentialsSecretRef: kafscale-s3-credentials
 ```
 
-### TLS configuration
+`spec.lfsProxy.s3.bucket` and `region` are required. The bucket name
+`kafscale-lfs` is permanently blocklisted at startup — use your own name.
+
+## LFS demo UI (optional)
+
+The chart can deploy a browser demo UI via `lfsDemos`:
+
+```bash
+helm upgrade --install kafscale deploy/helm/kafscale \
+  -f deploy/helm/kafscale/values-lfs-demo.yaml
+```
+
+This enables the demo UI only. LFS itself still requires `spec.lfsProxy` on your
+`KafscaleCluster`.
+
+## Core CRD settings
 
 ```yaml
-lfsProxy:
-  tls:
-    enabled: false
-    certSecretRef: lfs-proxy-tls
-  kafka:
-    sasl:
-      enabled: false
-      mechanism: SCRAM-SHA-256
-      credentialsSecretRef: kafka-sasl
+spec:
+  lfsProxy:
+    enabled: true
+    replicas: 1
+    http:
+      enabled: true
+      port: 8080
+      apiKeySecretRef: lfs-api-key
+    s3:
+      bucket: my-bucket
+      region: us-east-1
+      forcePathStyle: true   # Required for MinIO
+      credentialsSecretRef: s3-credentials
+    service:
+      type: ClusterIP
+      port: 9092
+    metrics:
+      enabled: true
+      port: 9095
 ```
 
-### Ingress
+## HTTP API
 
-```yaml
-lfsProxy:
-  ingress:
-    enabled: false
-    className: nginx
-    host: lfs.example.com
-    tls:
-      enabled: false
-      secretName: lfs-tls
-```
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/lfs/produce` | POST | Upload blob to S3, produce pointer to Kafka |
+| `/lfs/download` | POST | Get presigned URL or stream blob from S3 |
+| `/readyz` | GET | Readiness probe |
+| `/livez` | GET | Liveness probe |
+
+OpenAPI spec: [`api/lfs-proxy/openapi.yaml`](https://github.com/KafScale/platform/blob/main/api/lfs-proxy/openapi.yaml)
 
 ## Monitoring
 
-When `metrics.serviceMonitor.enabled` is set to `true`, the chart creates a Prometheus `ServiceMonitor` that scrapes the LFS proxy metrics endpoint.
-
-Key metrics:
+When `spec.lfsProxy.metrics.enabled` is true, the operator exposes a metrics
+Service on the configured port.
 
 | Metric | Type | Description |
-|---|---|---|
+|--------|------|-------------|
 | `lfs_uploads_total` | Counter | Total upload operations |
 | `lfs_downloads_total` | Counter | Total download operations |
 | `lfs_upload_bytes_total` | Counter | Total bytes uploaded |
@@ -154,4 +147,4 @@ cd deploy/docker-compose
 docker compose up -d
 ```
 
-This starts MinIO, a KafScale broker, and the LFS proxy with pre-configured defaults. See `deploy/docker-compose/README.md` for details.
+This starts MinIO, a KafScale broker, and the LFS proxy with pre-configured defaults.

--- a/_docs/operations.md
+++ b/_docs/operations.md
@@ -108,15 +108,28 @@ Broker pods exit immediately if they cannot read metadata or write a probe objec
 
 Each broker advertises a numeric `NodeID` in etcd. In a single-node demo you'll always see `Leader=0` in the Console's topic detail because the only broker has ID `0`. In real clusters those IDs align with the broker addresses the operator published; if you see `Leader=3`, look for the broker with `NodeID 3` in the metadata payload.
 
-## External Broker Access
+## External Kafka Access
 
-By default, brokers advertise the in-cluster service DNS name. That works for clients running inside Kubernetes, but external clients must connect to a reachable address. Configure both the broker Service exposure and the advertised address so clients learn the external endpoint from metadata responses.
+By default, brokers advertise the in-cluster service DNS name. That works for
+clients running inside Kubernetes. External clients need a reachable address in
+Metadata responses.
 
-See [Runtime Settings — External Broker Access](/configuration/#external-broker-access) for all CRD fields.
+**Recommended:** deploy the Kafka-aware proxy (`proxy.enabled=true`). When the
+proxy is enabled, clients connect to the **proxy Service**, not individual broker
+pods. The proxy answers Metadata/FindCoordinator with a single stable endpoint,
+then forwards all other Kafka requests to brokers.
 
-### Kafka Proxy (recommended for external access)
+**Optional:** expose brokers directly via `KafscaleCluster` `spec.brokers` Service
+settings. Use this only when you intentionally bypass the proxy. Broker NodePort
+does not replace the proxy entrypoint in scaled deployments.
 
-For external clients plus broker churn, deploy the Kafka-aware proxy. It answers Metadata/FindCoordinator requests with a single stable endpoint (the proxy service), then forwards all other Kafka requests to the brokers. This keeps clients connected even as broker pods scale or rotate.
+The Helm chart does **not** ship a Kafka Ingress resource. External TLS uses
+LoadBalancer annotations or an external TCP gateway (see
+[Proxy TLS via LoadBalancer](#proxy-tls-via-loadbalancer-recommended)).
+
+See [Runtime Settings — External Kafka Access](/configuration/#external-kafka-access) for CRD and Helm fields.
+
+### Kafka Proxy (recommended)
 
 Recommended settings:
 - Run 2+ proxy replicas behind a LoadBalancer service
@@ -137,9 +150,27 @@ helm upgrade --install kafscale deploy/helm/kafscale \
   --set proxy.etcdEndpoints[0]=http://kafscale-etcd-client.kafscale.svc.cluster.local:2379
 ```
 
-### Direct broker exposure
+For local clusters (kind, minikube), pin the proxy NodePort so host port mappings
+stay stable. Set `proxy.service.type=NodePort` and `proxy.service.nodePort` to a
+value in `30000–32767`, then set `proxy.advertisedHost` to the node IP.
 
-Use direct broker Service settings when you intentionally expose dedicated brokers (for example, isolating traffic or pinning producers to specific nodes). This requires explicit endpoint management.
+Example (kind / local dev):
+
+```bash
+helm upgrade --install kafscale deploy/helm/kafscale \
+  --namespace kafscale --create-namespace \
+  --set proxy.enabled=true \
+  --set proxy.service.type=NodePort \
+  --set proxy.service.nodePort=30092 \
+  --set proxy.advertisedHost=127.0.0.1 \
+  --set proxy.advertisedPort=30092 \
+  --set proxy.etcdEndpoints[0]=http://kafscale-etcd-client.kafscale.svc.cluster.local:2379
+```
+
+### Direct broker exposure (optional)
+
+Use direct broker Service settings when you intentionally expose dedicated brokers
+(for example, isolating traffic or pinning producers to specific nodes).
 
 Example (GKE/AWS/Azure load balancer):
 

--- a/_docs/quickstart.md
+++ b/_docs/quickstart.md
@@ -169,12 +169,13 @@ segment-00000000000000000000.kfs
 segment-00000000000000000000.index
 ```
 
-## External broker access
+## External Kafka access
 
-External clients: configure `spec.brokers.advertisedHost` / `advertisedPort` and
-`spec.brokers.service` in your `KafscaleCluster` so Kafka clients learn a
-reachable endpoint. See `docs/operations.md` and `deploy/helm/README.md` for
-examples.
+External clients: enable the Kafka proxy (`proxy.enabled=true`) and set
+`proxy.advertisedHost` / `proxy.advertisedPort` so clients learn a stable
+endpoint. For local clusters, pin `proxy.service.nodePort` (see
+[Operations](/operations/)). Direct broker exposure via `spec.brokers.service` is
+optional when you intentionally bypass the proxy.
 
 ---
 


### PR DESCRIPTION
Mirror doc refresh on kafscale.io: proxy-first access, NodePort, LFS via CRD.