### PR TITLE
fix(metadata): serialize etcd snapshot persist and refresh

### DIFF
--- a/cmd/kafscale-cli/main_test.go
+++ b/cmd/kafscale-cli/main_test.go
@@ -35,6 +35,16 @@ import (
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
+func newTestEtcdStore(t *testing.T, ctx context.Context, initial metadata.ClusterMetadata, endpoints []string) *metadata.EtcdStore {
+	t.Helper()
+	store, err := metadata.NewEtcdStore(ctx, initial, metadata.EtcdStoreConfig{Endpoints: endpoints})
+	if err != nil {
+		t.Fatalf("NewEtcdStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
 type failingListS3 struct {
 	*storage.MemoryS3Client
 	err error
@@ -76,16 +86,12 @@ func TestRunRestoreCommandUsesInjectedClients(t *testing.T) {
 	endpoints := testutil.StartEmbeddedEtcd(t)
 	ctx := context.Background()
 
-	store, err := metadata.NewEtcdStore(ctx, metadata.ClusterMetadata{
+	store := newTestEtcdStore(t, ctx, metadata.ClusterMetadata{
 		Brokers: []protocol.MetadataBroker{
 			{NodeID: 1, Host: "broker-0", Port: 9092},
 		},
 		ControllerID: 1,
-	}, metadata.EtcdStoreConfig{Endpoints: endpoints})
-	if err != nil {
-		t.Fatalf("NewEtcdStore: %v", err)
-	}
-	defer func() { _ = store.EtcdClient().Close() }()
+	}, endpoints)
 
 	if _, err := store.CreateTopic(ctx, metadata.TopicSpec{
 		Name:              "orders",
@@ -209,16 +215,12 @@ func TestExecuteRestoreCreatesRecoveredTopic(t *testing.T) {
 	endpoints := testutil.StartEmbeddedEtcd(t)
 	ctx := context.Background()
 
-	store, err := metadata.NewEtcdStore(ctx, metadata.ClusterMetadata{
+	store := newTestEtcdStore(t, ctx, metadata.ClusterMetadata{
 		Brokers: []protocol.MetadataBroker{
 			{NodeID: 1, Host: "broker-0", Port: 9092},
 		},
 		ControllerID: 1,
-	}, metadata.EtcdStoreConfig{Endpoints: endpoints})
-	if err != nil {
-		t.Fatalf("NewEtcdStore: %v", err)
-	}
-	defer func() { _ = store.EtcdClient().Close() }()
+	}, endpoints)
 
 	if _, err := store.CreateTopic(ctx, metadata.TopicSpec{
 		Name:              "orders",
@@ -353,7 +355,7 @@ func TestExecuteRestoreRejectsUnknownPartition(t *testing.T) {
 	endpoints := testutil.StartEmbeddedEtcd(t)
 	ctx := context.Background()
 
-	store, err := metadata.NewEtcdStore(ctx, metadata.ClusterMetadata{
+	store := newTestEtcdStore(t, ctx, metadata.ClusterMetadata{
 		Brokers: []protocol.MetadataBroker{
 			{NodeID: 1, Host: "broker-0", Port: 9092},
 		},
@@ -366,13 +368,9 @@ func TestExecuteRestoreRejectsUnknownPartition(t *testing.T) {
 				},
 			},
 		},
-	}, metadata.EtcdStoreConfig{Endpoints: endpoints})
-	if err != nil {
-		t.Fatalf("NewEtcdStore: %v", err)
-	}
-	defer func() { _ = store.EtcdClient().Close() }()
+	}, endpoints)
 
-	err = executeRestore(ctx, &bytes.Buffer{}, restoreConfig{
+	err := executeRestore(ctx, &bytes.Buffer{}, restoreConfig{
 		SourceTopic:     "orders",
 		SourceNamespace: "default",
 		TargetTopic:     "orders-restored",
@@ -389,16 +387,12 @@ func TestExecuteRestoreRollsBackTargetTopicOnRecoveryFailure(t *testing.T) {
 	endpoints := testutil.StartEmbeddedEtcd(t)
 	ctx := context.Background()
 
-	store, err := metadata.NewEtcdStore(ctx, metadata.ClusterMetadata{
+	store := newTestEtcdStore(t, ctx, metadata.ClusterMetadata{
 		Brokers: []protocol.MetadataBroker{
 			{NodeID: 1, Host: "broker-0", Port: 9092},
 		},
 		ControllerID: 1,
-	}, metadata.EtcdStoreConfig{Endpoints: endpoints})
-	if err != nil {
-		t.Fatalf("NewEtcdStore: %v", err)
-	}
-	defer func() { _ = store.EtcdClient().Close() }()
+	}, endpoints)
 
 	if _, err := store.CreateTopic(ctx, metadata.TopicSpec{
 		Name:              "orders",
@@ -412,7 +406,7 @@ func TestExecuteRestoreRollsBackTargetTopicOnRecoveryFailure(t *testing.T) {
 		MemoryS3Client: storage.NewMemoryS3Client(),
 		err:            errors.New("list failed"),
 	}
-	err = executeRestore(ctx, &bytes.Buffer{}, restoreConfig{
+	err := executeRestore(ctx, &bytes.Buffer{}, restoreConfig{
 		SourceTopic:     "orders",
 		SourceNamespace: "default",
 		TargetTopic:     "orders-restored",
@@ -436,16 +430,12 @@ func TestExecuteRestoreRollsBackCopiedS3ObjectsOnPartialFailure(t *testing.T) {
 	endpoints := testutil.StartEmbeddedEtcd(t)
 	ctx := context.Background()
 
-	store, err := metadata.NewEtcdStore(ctx, metadata.ClusterMetadata{
+	store := newTestEtcdStore(t, ctx, metadata.ClusterMetadata{
 		Brokers: []protocol.MetadataBroker{
 			{NodeID: 1, Host: "broker-0", Port: 9092},
 		},
 		ControllerID: 1,
-	}, metadata.EtcdStoreConfig{Endpoints: endpoints})
-	if err != nil {
-		t.Fatalf("NewEtcdStore: %v", err)
-	}
-	defer func() { _ = store.EtcdClient().Close() }()
+	}, endpoints)
 
 	if _, err := store.CreateTopic(ctx, metadata.TopicSpec{
 		Name:              "orders",

--- a/pkg/metadata/etcd_store.go
+++ b/pkg/metadata/etcd_store.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -50,6 +51,7 @@ type EtcdStore struct {
 	cancel    context.CancelFunc
 	available int32
 	lastError atomic.Value // stores etcdError
+	persistMu sync.Mutex    // serializes snapshot read/write to avoid out-of-order etcd puts
 }
 
 func (s *EtcdStore) EtcdClient() *clientv3.Client {
@@ -521,6 +523,9 @@ func (s *EtcdStore) watchSnapshot(ctx context.Context) {
 }
 
 func (s *EtcdStore) refreshSnapshot(ctx context.Context) error {
+	s.persistMu.Lock()
+	defer s.persistMu.Unlock()
+
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	resp, err := s.client.Get(ctx, snapshotKey())
@@ -545,6 +550,9 @@ func snapshotKey() string {
 }
 
 func (s *EtcdStore) persistSnapshot(ctx context.Context) error {
+	s.persistMu.Lock()
+	defer s.persistMu.Unlock()
+
 	state, err := s.metadata.Metadata(context.Background(), nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
- Serialize `persistSnapshot` and `refreshSnapshot` with a mutex so overlapping etcd puts cannot publish stale cluster state (fixes restore rollback flake on main after #151 merge)
- Close `EtcdStore` watchers in `kafscale-cli` tests to avoid leaked goroutines under `-race`

## Context
Main CI failed after merging #151 with `TestExecuteRestoreRollsBackTargetTopicOnRecoveryFailure`: a slow `CreateTopic` snapshot persist could complete after rollback `DeleteTopic` and reintroduce the target topic.

## Test plan
- [x] `go test -race -count=20 ./cmd/kafscale-cli/ -run TestExecuteRestoreRollsBack`
- [x] `go test -race -count=10 ./pkg/metadata/ -run TestEtcdStoreTopicConfigAndPartitions`