### PR TITLE
fix(java-sdk): bump jackson-databind to 2.21.5

### DIFF
--- a/lfs-client-sdk/java/pom.xml
+++ b/lfs-client-sdk/java/pom.xml
@@ -31,7 +31,7 @@ limitations under the License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <kafka.clients.version>4.1.2</kafka.clients.version>
     <aws.sdk.version>2.31.5</aws.sdk.version>
-    <jackson.version>2.19.1</jackson.version>
+    <jackson.version>2.21.5</jackson.version>
     <junit.jupiter.version>5.11.0</junit.jupiter.version>
     <testcontainers.version>1.20.2</testcontainers.version>
   </properties>


### PR DESCRIPTION
Resolves four new Dependabot alerts (#78-#81) for polymorphic deserialization and InetSocketAddress SSRF CVEs introduced after the 2.19.1 bump in #166.